### PR TITLE
nix: split shell in default and slow

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,26 +65,21 @@
 
             settings.global.excludes = ["_build" "result" ".direnv" "vendors/*" "vendored-dune/*"];
           };
-        in {
-          packages = {
-            ligo = ligo;
-            default = ligo;
-          };
 
-          devShells = rec {
-            default = pkgs.mkShell {
+          ligo-shell = slow: {
               name = "ligo-dev-shell";
 
               inputsFrom = [ligo];
 
               buildInputs = with pkgs; [
                 alejandra
-                shellcheck
                 ocamlformat
                 ocamlPackages.utop
                 ocamlPackages.ocaml-lsp
                 ocamlPackages.merlin
                 ocamlPackages.merlin-lib
+              ] ++ lib.optionals slow [
+                shellcheck
                 emacsPackages.merlin
                 emacsPackages.merlin-company
               ];
@@ -95,6 +90,15 @@
                 export TREE_SITTER_TYPESCRIPT="${ligo.TREE_SITTER_TYPESCRIPT}";
               '';
             };
+        in {
+          packages = {
+            ligo = ligo;
+            default = ligo;
+          };
+
+          devShells = rec {
+            default = pkgs.mkShell (ligo-shell false);
+            slow = pkgs.mkShell (ligo-shell true);
           };
 
           formatter = fmt.config.build.wrapper;

--- a/gitlab-pages/website/docusaurus.config.js
+++ b/gitlab-pages/website/docusaurus.config.js
@@ -133,7 +133,7 @@ const config = {
             items: [
               {
                 label: "Discord",
-                href: "https://discord.gg/tezos-blockchain-699325006928281720",
+                href: "https://discord.gg/tezos",
                 rel: "noopener noreferrer nofollow",
               },
               {

--- a/gitlab-pages/website/src/components/Community/index.tsx
+++ b/gitlab-pages/website/src/components/Community/index.tsx
@@ -30,7 +30,7 @@ const Community = ({ discordMembers, contributors = 78, packages }: CommunityPro
         "The Ligo community is growing fast. Join our Discord to talk about the Tezos ecosystem, find help, and discover a lot more.",
       cta: {
         label: "join our discord",
-        href: "https://discord.gg/tezos-blockchain-699325006928281720",
+        href: "https://discord.gg/tezos",
         rel: "noopener noreferrer nofollow",
       },
     },

--- a/gitlab-pages/website/src/theme/Footer/Layout/index.js
+++ b/gitlab-pages/website/src/theme/Footer/Layout/index.js
@@ -7,7 +7,7 @@ import styles from "./index.module.scss";
 
 const COMMUNICATION_CHANNELS = [
   {
-    link: "https://discord.gg/tezos-blockchain-699325006928281720",
+    link: "https://discord.gg/tezos",
     icon: {
       src: "img/communication_channels/discord.svg",
       width: "30",

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -76,4 +76,7 @@ with prev; {
   bison = prev.bison.overrideAttrs (oldAttrs: {
     doCheck = false;
   });
+  p11-kit = prev.p11-kit.overrideAttrs (oldAttrs: {
+    doCheck = false;
+  });
 }


### PR DESCRIPTION
## Description

Currently all Ligo tools are included in the `default` shell, two of those tools are only useful in specific situations and incur in a major build time problem, namely the `shellcheck` when playing with shell scripts and `emacsPackages` for emacs users.

This PR moves both under an alternative shell `#slow` it can be used through `nix develop .#slow`. This improves drastically the cold build time.

## Related

- #8
