### PR TITLE
[doc] Create a page for the @public decorator 

### DIFF
--- a/gitlab-pages/docs/advanced/attributes-decorators.md
+++ b/gitlab-pages/docs/advanced/attributes-decorators.md
@@ -96,7 +96,6 @@ Furthermore, the following attributes are used internally by the compiler, you m
 
 * `@thunk`
 * `@hidden`
-* `@public`
 * `@deprecated`
 
 </Syntax>

--- a/gitlab-pages/docs/reference/decorators/public.md
+++ b/gitlab-pages/docs/reference/decorators/public.md
@@ -1,0 +1,20 @@
+---
+id: public
+title: public
+---
+
+import Syntax from '@theme/Syntax';
+
+<Syntax syntax="cameligo">
+
+The attribute `[@public]` labels a declaration as available to be called by other pieces of code.
+Because code is public by default in CameLIGO, this attribute is not needed in that syntax.
+
+</Syntax>
+
+<Syntax syntax="jsligo">
+
+The decorator `@public` labels a declaration as available to be called by other pieces of code, similar to the `export` keyword.
+This decorator is needed only when you want to make a namespace available to code in other files, as described in [Importing namespaces](../../preprocessor/import#importing-namespaces).
+
+</Syntax>

--- a/gitlab-pages/docs/syntax/decorators.md
+++ b/gitlab-pages/docs/syntax/decorators.md
@@ -39,7 +39,6 @@ You may encounter them when exporting the Abstract Syntax Tree (AST) after a cer
 
 * `[@thunk]`
 * `[@hidden]`
-* `[@public]`
 
 ## List of attributes
 
@@ -83,4 +82,5 @@ LIGO supports these decorators:
 - [`inline`](../reference/decorators/inline)
 - [`layout`](../reference/decorators/layout)
 - [`private`](../reference/decorators/private)
+- [`public`](../reference/decorators/public)
 - [`view`](../reference/decorators/view)

--- a/gitlab-pages/website/sidebars.js
+++ b/gitlab-pages/website/sidebars.js
@@ -190,6 +190,7 @@ const sidebars = {
           "reference/decorators/inline",
           "reference/decorators/layout",
           "reference/decorators/private",
+          "reference/decorators/public",
           "reference/decorators/view"
         ],
       },


### PR DESCRIPTION
The @public decorator is documented as never being necessary, but we found a place where it's necessary.