### PR TITLE
fix(doc): use relative links

### DIFF
--- a/gitlab-pages/docs/advanced/package-management.md
+++ b/gitlab-pages/docs/advanced/package-management.md
@@ -60,7 +60,7 @@ Earlier versions of LIGO used [`esy`](https://esy.sh) as the backend for package
 
 ### Workflow
 
-We will need the LIGO compiler to compile smart contracts, to get the LIGO compiler follow these [instructions](https://ligolang.org/docs/intro/installation).
+We will need the LIGO compiler to compile smart contracts, to get the LIGO compiler follow these [instructions](../intro/installation).
 
 Next, we will use a simple dependency `@ligo/math-lib` published on the LIGO registry. To download & install the library, run,
 

--- a/gitlab-pages/docs/intro/installation.md
+++ b/gitlab-pages/docs/intro/installation.md
@@ -16,7 +16,7 @@ You can also try LIGO in a Gitpod environment
 
 Releases are available at the [releases page of GitLab project](https://gitlab.com/ligolang/ligo/-/releases). All the artifacts are attached there.
 
-If you wish to see the changelog, you can either run `ligo changelog` or go to [this page](https://ligolang.org/docs/next/intro/changelog). It contains links to corresponding releases, should you wish to download the artifacts.
+If you wish to see the changelog, you can either run `ligo changelog` or go to [this page](./changelog). It contains links to corresponding releases, should you wish to download the artifacts.
 
 ## Install
 <Tabs

--- a/gitlab-pages/docs/intro/ligo-intro.md
+++ b/gitlab-pages/docs/intro/ligo-intro.md
@@ -42,14 +42,14 @@ Even if LIGO currently offers **two syntaxes**, you'll need to **choose only one
   let store_hello (delta : int) (store : storage) : operation list * storage = [], "Hello"
 ```
 
-A significant advantage of the multi-syntax feature is to share knowledge, toolings, and [modules](https://ligolang.org/docs/language-basics/modules) (like [libraries](https://ligolang.org/docs/advanced/package-management) onto [registry](https://packages.ligolang.org/packages)) in a larger community.
+A significant advantage of the multi-syntax feature is to share knowledge, toolings, and [modules](../language-basics/modules) (like [libraries](../advanced/package-management) onto [registry](https://packages.ligolang.org/packages)) in a larger community.
 
 ### LIGO, designed to be cost-effective
 
 Unlike desktop, mobile, or web application development, smart
 contracts cannot rely on cheap CPU time and memory.  All resources
 contracts use are expensive and tracked as
-['gas costs'](https://ligolang.org/docs/tutorials/optimisation/#tezos-gas-model).
+['gas costs'](../tutorials/optimisation/#tezos-gas-model).
 
 The LIGO compiler generates optimised Michelson code, which will
 be cost-effective on Tezos.
@@ -69,9 +69,9 @@ LIGO will **bring people to web3** and by design **reduce the risk**
 But compiler design is insufficient, and LIGO uses **static analysis** to
 encourage people to write simple code, avoid anti-patterns, and use
 the
-[robust test framework](https://ligolang.org/docs/testing/testing)
+[robust test framework](../testing)
 which can simulate Tezos blockchain and offer
-[mutation tests](https://ligolang.org/docs/advanced/mutation-testing)
+[mutation tests](../testing/mutation-testing)
 
 For critical code, LIGO also keeps its compiled output unbloated making **possible to formally verify** the compiled output using a project like
 [Mi-Cho-Coq](https://gitlab.com/nomadic-labs/mi-cho-coq/).
@@ -92,26 +92,26 @@ For critical code, LIGO also keeps its compiled output unbloated making **possib
 
 ### Do you want to try LIGO?
 
-For a quick overview, [get-started]( https://ligolang.org/docs/tutorials/getting-started) is a good choice. [Webide](https://ide.ligolang.org/) can be used to avoid installation onto your laptop.
+For a quick overview, [get-started](../tutorials/getting-started) is a good choice. [Webide](https://ide.ligolang.org/) can be used to avoid installation onto your laptop.
 
 ### Do you want to learn LIGO?
 
 Your choice to learn LIGO is already available:
-- Read [basics](https://ligolang.org/docs/language-basics/types) to have a basic comprehension
-- Write your first [smart contract](https://ligolang.org/docs/tutorials/taco-shop/tezos-taco-shop-smart-contract).
+- Read [basics](../language-basics/types) to have a basic comprehension
+- Write your first [smart contract](../tutorials/taco-shop/tezos-taco-shop-smart-contract).
 - Others resources are available on [marigold.dev](https://www.marigold.dev/learn)
 
 ### Do you want to build a production-ready project?
 
 You will need a deeper comprehension:
-- Teach yourself how to structure your code with [Combining code](https://ligolang.org/docs/next/language-basics/modules) section
-- Learn how to [write tests](https://ligolang.org/docs/next/testing/testing?lang=jsligo) we strongly encourage to use [breathalyzer library from the LIGO registry.](https://packages.ligolang.org/package/ligo-breathalyzer)
-- Understand how to [secure a contract](https://ligolang.org/docs/tutorials/security)
+- Teach yourself how to structure your code with [Combining code](../language-basics/modules) section
+- Learn how to [write tests](../testing) we strongly encourage to use [breathalyzer library from the LIGO registry.](https://packages.ligolang.org/package/ligo-breathalyzer)
+- Understand how to [secure a contract](../tutorials/security)
 
 ### Dig deeper
 
 In the end, maybe you will want to:
-- [Optimize your code](https://ligolang.org/docs/tutorials/optimisation/)
-- [Interact with other contracts](https://ligolang.org/docs/tutorials/inter-contract-calls/)
+- [Optimize your code](../tutorials/optimisation/)
+- [Interact with other contracts](../tutorials/inter-contract-calls/)
 
 <!-- updated use of entry -->

--- a/gitlab-pages/docs/language-basics/composite-types.md
+++ b/gitlab-pages/docs/language-basics/composite-types.md
@@ -70,7 +70,7 @@ const my_ledger : ledger =
 </Syntax>
 
 Complementary to records are the *variant types*, which are described in the
-section on [pattern matching](https://ligolang.org/docs/language-basics/unit-option-pattern-matching#variant-types).
+section on [pattern matching](../language-basics/unit-option-pattern-matching#variant-types).
 Records are a product of types, while variant types are sums of types.
 
 <!-- updated use of entry -->

--- a/gitlab-pages/docs/tutorials/registry/what-is-the-registry.md
+++ b/gitlab-pages/docs/tutorials/registry/what-is-the-registry.md
@@ -11,7 +11,7 @@ Packages are similar to libraries. They're pieces of code made by the community 
 
 ### How to publish my own package?
 
-You can refer to [this documentation](https://ligolang.org/docs/advanced/package-management#packaging) to learn how to turn LIGO files into a library and publish them.
+You can refer to [this documentation](../../advanced/package-management#packaging) to learn how to turn LIGO files into a library and publish them.
 
 ## [Contracts](https://packages.ligolang.org/contracts)
 

--- a/gitlab-pages/docs/tutorials/taco-shop/tezos-taco-shop-smart-contract.md
+++ b/gitlab-pages/docs/tutorials/taco-shop/tezos-taco-shop-smart-contract.md
@@ -149,7 +149,7 @@ ligo compile contract taco_shop.mligo
 > To avoid warning at compilation, change `taco_kind_index` into `_taco_kind_index`, it'll tell to the compiler that this variable is authorized to not be used.
 
 
-A good practice is to scope your contract into a [module](https://ligolang.org/docs/language-basics/modules?lang=cameligo).
+A good practice is to scope your contract into a [module](../../language-basics/modules).
 
 <Syntax syntax="cameligo">
 
@@ -195,7 +195,7 @@ namespace TacoShop {
 
 </Syntax>
 
-There is an impact onto the compilation, now you have to tell to the compiler which [module](https://ligolang.org/docs/language-basics/modules?lang=cameligo) it need to compile :
+There is an impact onto the compilation, now you have to tell to the compiler which [module](../../language-basics/modules) it need to compile :
 
 ```
 ligo compile contract taco_shop.mligo -m TacoShop


### PR DESCRIPTION
Ideally we should be using root-relative links but for now change these absolute links to relative so they will work when we move to ligo.tezos.com.