### PR TITLE
chore(ci): run formatter on github

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
       - run: nix build -L .#ligo
+  format_nix:
+    name: Run Formatter on Ligo
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+      - run: nix fmt

--- a/flake.nix
+++ b/flake.nix
@@ -73,9 +73,9 @@
           ligo = pkgs.callPackage ./nix/ligo.nix {inherit tezos-ligo tree-sitter-typescript grace lltz;};
 
           pkgs-extended = pkgs.extend (lib.composeManyExtensions [
-              build-yarn-package.overlays.default
-              haskell-nix.overlay
-              (import ./nix/haskell-overlay.nix)
+            build-yarn-package.overlays.default
+            haskell-nix.overlay
+            (import ./nix/haskell-overlay.nix)
           ]);
           ligo-syntaxes = ./tools/vscode/syntaxes;
           ligo-webide = pkgs-extended.callPackage ./nix/webide.nix {inherit ligo-syntaxes;};

--- a/lib/ligo_lltz_codgen/dune
+++ b/lib/ligo_lltz_codgen/dune
@@ -1,7 +1,15 @@
 (library
  (name ligo_lltz_codegen)
  (public_name ligo.lltz_codegen)
- (libraries ligo.tezos-utils core lltz.ir mini_c ptime lltz.codegen lltz.michelson)
+ (libraries
+  ligo.tezos-utils
+  core
+  lltz.ir
+  mini_c
+  ptime
+  lltz.codegen
+  lltz.michelson)
  (preprocess
   (pps ppx_jane))
-  (flags (:standard -w -26-27)))
+ (flags
+  (:standard -w -26-27)))

--- a/lib/ligo_lltz_codgen/ligo_lltz_codegen.ml
+++ b/lib/ligo_lltz_codgen/ligo_lltz_codegen.ml
@@ -10,11 +10,10 @@ module Michelson = Michelson
 
 let compile_location (loc : Location.t) : Range.t =
   match loc with
-    | File reg -> 
-      (try
-        Range.of_lex ~source:(`File reg#file) reg#byte_pos
-      with _ -> Range.initial (`String { content = ""; name = Some (reg#file) }))
-    | Virtual name -> Range.initial (`String { content = ""; name = Some name })
+  | File reg ->
+    (try Range.of_lex ~source:(`File reg#file) reg#byte_pos with
+    | _ -> Range.initial (`String { content = ""; name = Some reg#file }))
+  | Virtual name -> Range.initial (`String { content = ""; name = Some name })
 
 let dummy_loc = Location.generated
 let dummy_range = compile_location dummy_loc
@@ -39,8 +38,8 @@ let rec compile_type_expression (type_ : I.type_expression) : O.Type.t =
   | T_set elt_type -> return @@ Set (compile_type_expression elt_type)
   | T_contract arg_type -> return @@ Contract (compile_type_expression arg_type)
   | T_ticket type_ -> return @@ Ticket (compile_type_expression type_)
-  | T_sapling_state memo -> return @@ Sapling_state { memo = (Z.to_int memo) }
-  | T_sapling_transaction memo -> return @@ Sapling_transaction { memo = (Z.to_int memo) }
+  | T_sapling_state memo -> return @@ Sapling_state { memo = Z.to_int memo }
+  | T_sapling_transaction memo -> return @@ Sapling_transaction { memo = Z.to_int memo }
   | T_function (arg_type, ret_type) ->
     return @@ Function (compile_type_expression arg_type, compile_type_expression ret_type)
   | T_tuple annot_types -> return @@ Tuple (compile_row annot_types)
@@ -86,7 +85,7 @@ let compile_literal (lit : Literal_value.t) : O.Expr.constant =
   | Literal_unit -> Unit
   | Literal_int z -> Int z
   | Literal_nat z -> Nat z
-  | Literal_timestamp z -> 
+  | Literal_timestamp z ->
     (match Ptime.of_span (Ptime.Span.of_int_s (Z.to_int z)) with
     | Some time -> Timestamp (Ptime.to_rfc3339 time)
     | None -> assert false)
@@ -106,31 +105,38 @@ let compile_literal (lit : Literal_value.t) : O.Expr.constant =
   (* User cannot craft this literal, solely used for the interpreter *)
   | Literal_operation _ -> assert false
 
-let compile_constant (const : Constant.constant') (args: O.Expr.t list) (return_ty: O.Type.t) (range: Range.t): O.Expr.desc = 
-  let mk_prim ?(args=args) desc = O.Expr.Prim(desc, args) in
+let compile_constant
+    (const : Constant.constant')
+    (args : O.Expr.t list)
+    (return_ty : O.Type.t)
+    (range : Range.t)
+    : O.Expr.desc
+  =
+  let mk_prim ?(args = args) desc = O.Expr.Prim (desc, args) in
   match const with
   | C_UNIT -> mk_prim Unit
-  | C_NIL -> (match return_ty with
-  | { desc = List ty; _ } -> mk_prim (Nil (ty))
-  | _ -> assert false) 
+  | C_NIL ->
+    (match return_ty with
+    | { desc = List ty; _ } -> mk_prim (Nil ty)
+    | _ -> assert false)
   | C_SOME -> mk_prim Some
-  | C_NONE -> (
-    match return_ty with
+  | C_NONE ->
+    (match return_ty with
     | { desc = Option ty; _ } -> mk_prim (None ty)
     | _ -> assert false)
   | C_UPDATE -> assert false
   | C_ITER -> assert false
   | C_LOOP_LEFT -> assert false
-  | C_LOOP_CONTINUE -> (
-    match args, return_ty.desc with
-    | a::tl, Or (O.Row.Node [O.Row.Leaf(None, ty1);O.Row.Leaf(None, ty2)]) -> (O.Dsl.left ~range (None,None,ty2) a).desc
-    | _ -> assert false
-  )
-  | C_LOOP_STOP -> (
-    match args, return_ty.desc with
-    | a::tl, Or (O.Row.Node [O.Row.Leaf(None, ty1);O.Row.Leaf(None, ty2)]) -> (O.Dsl.right ~range (None,None,ty1) a).desc
-    | _ -> assert false
-  )
+  | C_LOOP_CONTINUE ->
+    (match args, return_ty.desc with
+    | a :: tl, Or (O.Row.Node [ O.Row.Leaf (None, ty1); O.Row.Leaf (None, ty2) ]) ->
+      (O.Dsl.left ~range (None, None, ty2) a).desc
+    | _ -> assert false)
+  | C_LOOP_STOP ->
+    (match args, return_ty.desc with
+    | a :: tl, Or (O.Row.Node [ O.Row.Leaf (None, ty1); O.Row.Leaf (None, ty2) ]) ->
+      (O.Dsl.right ~range (None, None, ty1) a).desc
+    | _ -> assert false)
   | C_FOLD -> assert false
   | C_FOLD_LEFT -> assert false
   | C_FOLD_RIGHT -> assert false
@@ -138,17 +144,18 @@ let compile_constant (const : Constant.constant') (args: O.Expr.t list) (return_
   | C_INT -> mk_prim Int
   | C_NEG -> mk_prim Neg
   | C_ADD -> mk_prim Add
-  | C_SUB -> (
-    match args with
-    | a::b::tl -> (O.Dsl.sub ~range a b).desc
+  | C_SUB ->
+    (match args with
+    | a :: b :: tl -> (O.Dsl.sub ~range a b).desc
     | _ -> assert false)
   | C_MUL -> mk_prim Mul
-  | C_DIV -> (
-    match args with
-    | a::b::tl -> (O.Dsl.div_ ~range a b).desc
+  | C_DIV ->
+    (match args with
+    | a :: b :: tl -> (O.Dsl.div_ ~range a b).desc
     | _ -> assert false)
-  | C_MOD -> (match args with
-    | a::b::tl -> (O.Dsl.mod_ ~range a b).desc
+  | C_MOD ->
+    (match args with
+    | a :: b :: tl -> (O.Dsl.mod_ ~range a b).desc
     | _ -> assert false)
   | C_NOT -> mk_prim Not
   | C_AND -> mk_prim And
@@ -159,82 +166,91 @@ let compile_constant (const : Constant.constant') (args: O.Expr.t list) (return_
   | C_LXOR -> mk_prim Xor
   | C_LSL -> mk_prim Lsl
   | C_LSR -> mk_prim Lsr
-  | C_EQ -> (
-    match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Eq
+  | C_EQ ->
+    (match args with
+    | a :: b :: tl -> mk_prim ~args:(O.Dsl.compare_ ~range a b :: tl) Eq
     | _ -> assert false)
-  | C_NEQ -> (
-    match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Neq
+  | C_NEQ ->
+    (match args with
+    | a :: b :: tl -> mk_prim ~args:(O.Dsl.compare_ ~range a b :: tl) Neq
     | _ -> assert false)
-  | C_LT -> (
-    match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Lt
+  | C_LT ->
+    (match args with
+    | a :: b :: tl -> mk_prim ~args:(O.Dsl.compare_ ~range a b :: tl) Lt
     | _ -> assert false)
-  | C_GT -> (
-    match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Gt
+  | C_GT ->
+    (match args with
+    | a :: b :: tl -> mk_prim ~args:(O.Dsl.compare_ ~range a b :: tl) Gt
     | _ -> assert false)
-  | C_LE -> (
-    match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Le
+  | C_LE ->
+    (match args with
+    | a :: b :: tl -> mk_prim ~args:(O.Dsl.compare_ ~range a b :: tl) Le
     | _ -> assert false)
-  | C_GE -> (
-    match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Ge
+  | C_GE ->
+    (match args with
+    | a :: b :: tl -> mk_prim ~args:(O.Dsl.compare_ ~range a b :: tl) Ge
     | _ -> assert false)
   | C_CONCAT -> mk_prim Concat2
   | C_CONCATS -> mk_prim Concat1
   | C_CONS -> mk_prim Cons
   | C_SIZE -> mk_prim Size
-  | C_SLICE -> (
-    match args with
-    | offset::length::seq::tl -> (
-      O.Dsl.if_none (O.Dsl.slice ~range offset ~length ~seq)
-        ~some:(let var_name = O.Dsl.gen_name () in
-          O.Dsl.annon_function var_name seq.type_ ~body:(O.Dsl.variable (Var var_name) seq.type_))
-        ~none:(O.Dsl.failwith ~range (O.Dsl.string ~range "Slice out of bounds"))
-      ).desc
+  | C_SLICE ->
+    (match args with
+    | offset :: length :: seq :: tl ->
+      (O.Dsl.if_none
+         (O.Dsl.slice ~range offset ~length ~seq)
+         ~some:
+           (let var_name = O.Dsl.gen_name () in
+            O.Dsl.annon_function
+              var_name
+              seq.type_
+              ~body:(O.Dsl.variable (Var var_name) seq.type_))
+         ~none:(O.Dsl.failwith ~range (O.Dsl.string ~range "Slice out of bounds")))
+        .desc
     | _ -> assert false)
   | C_PAIR -> mk_prim (Pair (None, None))
   | C_CAR -> mk_prim Car
   | C_CDR -> mk_prim Cdr
-  | C_TRUE -> O.Expr.Const(Bool true)
-  | C_FALSE -> O.Expr.Const(Bool false)
-  | C_LEFT -> (
-    match return_ty with
-    | { desc = Or (Node [Leaf(_,_); Leaf(_,ty2)]); _ } -> mk_prim (Left (None, None, ty2))
+  | C_TRUE -> O.Expr.Const (Bool true)
+  | C_FALSE -> O.Expr.Const (Bool false)
+  | C_LEFT ->
+    (match return_ty with
+    | { desc = Or (Node [ Leaf (_, _); Leaf (_, ty2) ]); _ } ->
+      mk_prim (Left (None, None, ty2))
     | _ -> assert false)
-  | C_RIGHT -> (
-    match return_ty with
-    | { desc = Or (Node [Leaf(_,ty1); Leaf(_,_)]); _ } -> mk_prim (Right (None, None, ty1))
+  | C_RIGHT ->
+    (match return_ty with
+    | { desc = Or (Node [ Leaf (_, ty1); Leaf (_, _) ]); _ } ->
+      mk_prim (Right (None, None, ty1))
     | _ -> assert false)
-  | C_SET_EMPTY -> (
-    match return_ty with
-    | { desc = Set ty; _ } -> mk_prim (Empty_set (ty))
+  | C_SET_EMPTY ->
+    (match return_ty with
+    | { desc = Set ty; _ } -> mk_prim (Empty_set ty)
     | _ -> assert false)
   | C_SET_LITERAL -> assert false
-  | C_SET_ADD -> 
+  | C_SET_ADD ->
     (match args with
-    | arg_hd::arg_tl -> mk_prim ~args:(arg_hd::(O.Dsl.bool ~range true)::arg_tl) Update
+    | arg_hd :: arg_tl ->
+      mk_prim ~args:(arg_hd :: O.Dsl.bool ~range true :: arg_tl) Update
     | _ -> assert false)
-  | C_SET_REMOVE -> 
+  | C_SET_REMOVE ->
     (match args with
-    | arg_hd::arg_tl -> mk_prim ~args:(arg_hd::(O.Dsl.bool ~range false)::arg_tl) Update
+    | arg_hd :: arg_tl ->
+      mk_prim ~args:(arg_hd :: O.Dsl.bool ~range false :: arg_tl) Update
     | _ -> assert false)
   | C_SET_ITER -> assert false
   | C_SET_FOLD -> assert false
   | C_SET_FOLD_DESC -> assert false
   | C_SET_MEM -> mk_prim Mem
-  | C_SET_UPDATE -> 
+  | C_SET_UPDATE ->
     (match args with
-    | elem::flag::coll -> mk_prim ~args:(elem::flag::coll) Update
+    | elem :: flag :: coll -> mk_prim ~args:(elem :: flag :: coll) Update
     | _ -> assert false)
   | C_SET_SIZE -> mk_prim Size
-  | C_LIST_EMPTY -> (
-    match return_ty with
-    | { desc = List ty; _ } -> mk_prim (Nil (ty))
-    | _ -> assert false) 
+  | C_LIST_EMPTY ->
+    (match return_ty with
+    | { desc = List ty; _ } -> mk_prim (Nil ty)
+    | _ -> assert false)
   | C_LIST_LITERAL -> assert false
   | C_LIST_ITER -> assert false
   | C_LIST_MAP -> assert false
@@ -242,52 +258,61 @@ let compile_constant (const : Constant.constant') (args: O.Expr.t list) (return_
   | C_LIST_FOLD_LEFT -> assert false
   | C_LIST_FOLD_RIGHT -> assert false
   | C_LIST_SIZE -> mk_prim Size
-  | C_MAP -> 
+  | C_MAP ->
     (match return_ty with
     | { desc = Map (key_ty, value_ty); _ } -> mk_prim (Empty_map (key_ty, value_ty))
     | _ -> assert false)
-  | C_MAP_EMPTY -> (
-    match return_ty with
+  | C_MAP_EMPTY ->
+    (match return_ty with
     | { desc = Map (key_ty, value_ty); _ } -> mk_prim (Empty_map (key_ty, value_ty))
     | _ -> assert false)
   | C_MAP_LITERAL -> assert false
   | C_MAP_GET -> mk_prim Get
   | C_MAP_GET_FORCE -> assert false
-  | C_MAP_ADD -> (
-    match args with
-    | key::value::arg_tl -> mk_prim ~args:(key::(O.Dsl.some ~range value)::arg_tl) Update
+  | C_MAP_ADD ->
+    (match args with
+    | key :: value :: arg_tl ->
+      mk_prim ~args:(key :: O.Dsl.some ~range value :: arg_tl) Update
     | _ -> assert false)
-  | C_MAP_REMOVE -> (
-    match args, return_ty with
-    | key::arg_tl, { desc = Map (key_ty, value_ty); _ } -> mk_prim ~args:(key::(O.Dsl.none ~range value_ty)::arg_tl) Update
+  | C_MAP_REMOVE ->
+    (match args, return_ty with
+    | key :: arg_tl, { desc = Map (key_ty, value_ty); _ } ->
+      mk_prim ~args:(key :: O.Dsl.none ~range value_ty :: arg_tl) Update
     | _ -> assert false)
   | C_MAP_UPDATE -> mk_prim Update
   | C_MAP_ITER -> assert false
   | C_MAP_MAP -> assert false
   | C_MAP_FOLD -> assert false
-  | C_MAP_FIND -> (
-    match args with
-    | key::coll::tl -> (
-      O.Dsl.if_none (O.Dsl.get ~range key coll)
-        ~some:(let var_name = O.Dsl.gen_name () in
-          (match coll.type_ with
-          | { desc = Map (key_ty, value_ty); _ } -> O.Dsl.annon_function var_name value_ty ~body:(O.Dsl.variable (Var var_name) value_ty)
-          | _ -> assert false)
-          )
-        ~none:(O.Dsl.failwith ~range (O.Dsl.string ~range "Key not found"))
-      ).desc
+  | C_MAP_FIND ->
+    (match args with
+    | key :: coll :: tl ->
+      (O.Dsl.if_none
+         (O.Dsl.get ~range key coll)
+         ~some:
+           (let var_name = O.Dsl.gen_name () in
+            match coll.type_ with
+            | { desc = Map (key_ty, value_ty); _ } ->
+              O.Dsl.annon_function
+                var_name
+                value_ty
+                ~body:(O.Dsl.variable (Var var_name) value_ty)
+            | _ -> assert false)
+         ~none:(O.Dsl.failwith ~range (O.Dsl.string ~range "Key not found")))
+        .desc
     | _ -> assert false)
-  | C_MAP_FIND_OPT -> mk_prim Get 
+  | C_MAP_FIND_OPT -> mk_prim Get
   | C_MAP_GET_AND_UPDATE -> mk_prim Get_and_update
   | C_MAP_SIZE -> mk_prim Size
   | C_MAP_MEM -> mk_prim Mem
-  | C_BIG_MAP -> (
-    match return_ty with
-    | { desc = Big_map (key_ty, value_ty); _ } -> mk_prim (Empty_bigmap (key_ty, value_ty))
+  | C_BIG_MAP ->
+    (match return_ty with
+    | { desc = Big_map (key_ty, value_ty); _ } ->
+      mk_prim (Empty_bigmap (key_ty, value_ty))
     | _ -> assert false)
-  | C_BIG_MAP_EMPTY -> (
-    match return_ty with
-    | { desc = Big_map (key_ty, value_ty); _ } -> mk_prim (Empty_bigmap (key_ty, value_ty))
+  | C_BIG_MAP_EMPTY ->
+    (match return_ty with
+    | { desc = Big_map (key_ty, value_ty); _ } ->
+      mk_prim (Empty_bigmap (key_ty, value_ty))
     | _ -> assert false)
   | C_BIG_MAP_LITERAL -> assert false
   | C_BIG_MAP_GET_AND_UPDATE -> mk_prim Get_and_update
@@ -365,8 +390,8 @@ let compile_constant (const : Constant.constant') (args: O.Expr.t list) (return_
     (* only interpreter *)
     assert false
   | C_GLOBAL_CONSTANT ->
-    (* TODO: removed in ?? *) 
-    assert false 
+    (* TODO: removed in ?? *)
+    assert false
   | C_POLYMORPHIC_ADD ->
     (* removed in checking *)
     assert false
@@ -407,34 +432,38 @@ let compile_micheline_seq nodes =
 let rec compile_expression (expr : I.expression) : O.Expr.t =
   let return_ty = compile_type_expression expr.type_expression in
   let range = compile_location expr.location in
-  let return (desc : O.Expr.desc) : O.Expr.t =
-    { desc; range = range; type_ = return_ty }
-  in
+  let return (desc : O.Expr.desc) : O.Expr.t = { desc; range; type_ = return_ty } in
   match expr.content with
   | E_literal lit -> return @@ Const (compile_literal lit)
   | E_closure func ->
     let var, _return_type, body = compile_function func in
-    let var_ty = (match return_ty with
-    | { desc = O.Type.Function (var_ty, _return_type); _ } -> var_ty
-    | _ -> assert false) in
-    return @@ O.Expr.Lambda { lam_var = (var, var_ty); body }
-  | E_rec { func; rec_binder } -> 
+    let var_ty =
+      match return_ty with
+      | { desc = O.Type.Function (var_ty, _return_type); _ } -> var_ty
+      | _ -> assert false
+    in
+    return @@ O.Expr.Lambda { lam_var = var, var_ty; body }
+  | E_rec { func; rec_binder } ->
     let rec_var = compile_var rec_binder in
     let var, _return_type, body = compile_function func in
-    let var_ty = (match return_ty with
-    | { desc = O.Type.Function (var_ty, _return_type); _ } -> var_ty
-    | _ -> assert false) in
-    return @@ Lambda_rec { mu_var = (rec_var, return_ty); lambda ={lam_var = (var, var_ty); body} }
+    let var_ty =
+      match return_ty with
+      | { desc = O.Type.Function (var_ty, _return_type); _ } -> var_ty
+      | _ -> assert false
+    in
+    return
+    @@ Lambda_rec
+         { mu_var = rec_var, return_ty; lambda = { lam_var = var, var_ty; body } }
   | E_constant { cons_name; arguments } ->
     let args = List.map arguments ~f:compile_expression in
-    return @@ (compile_constant cons_name args return_ty range)
+    return @@ compile_constant cons_name args return_ty range
   | E_application (abs, arg) ->
     let abs = compile_expression abs in
     let arg = compile_expression arg in
     return @@ App { abs; arg }
-  | E_variable var -> return @@ (Variable (compile_var var))
+  | E_variable var -> return @@ Variable (compile_var var)
   | E_let_in (rhs, _inline, (binder, in_)) ->
-    let (let_var, _) = compile_binder binder in
+    let let_var, _ = compile_binder binder in
     let rhs = compile_expression rhs in
     let in_ = compile_expression in_ in
     return @@ Let_in { let_var; rhs; in_ }
@@ -453,19 +482,24 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
     let if_true = compile_expression if_true in
     let if_false = compile_expression if_false in
     return @@ If_bool { condition; if_true; if_false }
-  | E_if_cons (subject, if_nil, ((hd_binder, tl_binder), if_cons)) -> 
+  | E_if_cons (subject, if_nil, ((hd_binder, tl_binder), if_cons)) ->
     let subject = compile_expression subject in
     let if_nil = compile_expression if_nil in
     let hd_binder = compile_binder hd_binder in
     let tl_binder = compile_binder tl_binder in
     let if_cons = compile_expression if_cons in
-    return @@ If_cons { subject; if_empty = if_nil; if_nonempty = {lam_var1 = hd_binder; lam_var2 = tl_binder; body = if_cons} }
+    return
+    @@ If_cons
+         { subject
+         ; if_empty = if_nil
+         ; if_nonempty = { lam_var1 = hd_binder; lam_var2 = tl_binder; body = if_cons }
+         }
   | E_if_none (subject, if_none, (binder, if_some)) ->
     let subject = compile_expression subject in
     let if_none = compile_expression if_none in
     let binder = compile_binder binder in
     let if_some = compile_expression if_some in
-    return @@ If_none { subject; if_none; if_some = {lam_var = binder; body = if_some} }
+    return @@ If_none { subject; if_none; if_some = { lam_var = binder; body = if_some } }
   | E_if_left (subject, (left_binder, if_left), (right_binder, if_right)) ->
     let subject = compile_expression subject in
     let left_binder = compile_binder left_binder in
@@ -474,7 +508,10 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
     let if_right = compile_expression if_right in
     return
     @@ If_left
-         { subject; if_left = {lam_var = left_binder; body = if_left}; if_right = {lam_var = right_binder; body=if_right} }
+         { subject
+         ; if_left = { lam_var = left_binder; body = if_left }
+         ; if_right = { lam_var = right_binder; body = if_right }
+         }
   | E_while (cond, body) ->
     let cond = compile_expression cond in
     let body = compile_expression body in
@@ -485,14 +522,21 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
     let step = compile_expression step in
     let index, index_ty = compile_mut_binder index in
     let body = compile_expression body in
-    return @@ For { init = start; 
-      cond = O.Dsl.le ~range (O.Dsl.deref ~range index index_ty) (stop); 
-      update = O.Dsl.assign index (O.Dsl.add ~range (O.Dsl.deref ~range index index_ty) step); 
-      index; body }
+    return
+    @@ For
+         { init = start
+         ; cond = O.Dsl.le ~range (O.Dsl.deref ~range index index_ty) stop
+         ; update =
+             O.Dsl.assign
+               index
+               (O.Dsl.add ~range (O.Dsl.deref ~range index index_ty) step)
+         ; index
+         ; body
+         }
   | E_for_each (collection, _type, (binders, body)) ->
     let collection = compile_expression collection in
     let var, body = compile_binders binders ~in_:(compile_expression body) in
-    return @@ For_each { collection; body = {lam_var = var; body} }
+    return @@ For_each { collection; body = { lam_var = var; body } }
   | E_tuple elts ->
     let elts = List.map elts ~f:compile_expression in
     let row = O.Row.(Node (List.map elts ~f:(fun elt -> Leaf (None, elt)))) in
@@ -514,23 +558,24 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
     let binder = compile_binder binder in
     let body = compile_expression body in
     (match iter_const with
-    | Constant.C_ITER -> return @@ For_each { collection; body = {lam_var = binder; body} }
-    | Constant.C_MAP -> return @@ Map { collection; map = {lam_var = binder; body} }
+    | Constant.C_ITER ->
+      return @@ For_each { collection; body = { lam_var = binder; body } }
+    | Constant.C_MAP -> return @@ Map { collection; map = { lam_var = binder; body } }
     | Constant.C_LOOP_LEFT ->
-      return @@ While_left { cond = collection; body = {lam_var = binder; body} }
+      return @@ While_left { cond = collection; body = { lam_var = binder; body } }
     | _ -> assert false)
   | E_fold ((binder, body), collection, init) ->
     let collection = compile_expression collection in
     let init = compile_expression init in
     let binder = compile_binder binder in
     let body = compile_expression body in
-    return @@ Fold_left { collection; init; fold = {lam_var=binder; body} }
+    return @@ Fold_left { collection; init; fold = { lam_var = binder; body } }
   | E_fold_right ((binder, body), (collection, _elt_type), init) ->
     let collection = compile_expression collection in
     let init = compile_expression init in
     let binder = compile_binder binder in
     let body = compile_expression body in
-    return @@ Fold_right { collection; init; fold = {lam_var=binder; body} }
+    return @@ Fold_right { collection; init; fold = { lam_var = binder; body } }
   | I.E_raw_michelson nodes ->
     let micheline = compile_micheline_seq nodes in
     let var = compile_var (Value_var.fresh ~loc:dummy_loc ()) in
@@ -538,14 +583,21 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
     | { desc = O.Type.Function (var_ty, body_ty); _ } ->
       return
       @@ Lambda
-           { lam_var = (var, var_ty)
-           ; body = {desc = Raw_michelson { michelson = micheline; args = [ O.Dsl.variable ~range var var_ty ]}; range = range; type_= body_ty}
+           { lam_var = var, var_ty
+           ; body =
+               { desc =
+                   Raw_michelson
+                     { michelson = micheline
+                     ; args = [ O.Dsl.variable ~range var var_ty ]
+                     }
+               ; range
+               ; type_ = body_ty
+               }
            }
     | _ -> assert false)
   | E_inline_michelson (code, args') ->
     let micheline, args = compile_inline_michelson (code, args') in
     return @@ Raw_michelson { michelson = micheline; args }
-
   | I.E_global_constant (hash, args) ->
     assert false
     (*TODO: let args = List.map args ~f:compile_expression in
@@ -556,7 +608,6 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
        ; (constant <hash>)
 
        }  *)*)
-
   | I.E_create_contract
       ( parameter_type
       , storage_type
@@ -571,8 +622,7 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
     let initial_storage = compile_expression initial_storage in
     return
     @@ Create_contract
-         { 
-         storage
+         { storage
          ; code = { lam_var = binder; body = code }
          ; delegate
          ; initial_balance
@@ -580,7 +630,11 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
          }
   | E_create_contract _ -> assert false
 
-and compile_contract (binder:Value_var.t) (input_ty: I.type_expression) (body:I.expression) =
+and compile_contract
+    (binder : Value_var.t)
+    (input_ty : I.type_expression)
+    (body : I.expression)
+  =
   let binder = compile_var binder in
   let input_ty = compile_type_expression input_ty in
   let body = compile_expression body in
@@ -595,117 +649,128 @@ and compile_function ({ binder; body } : I.anon_function) =
 and compile_tuple_index (index : int) : O.Row.Path.t = O.Row.Path.Here [ index ]
 
 and compile_binders binders ~(in_ : O.Expr.t) : (O.Expr.var * O.Type.t) * O.Expr.t =
-  let create_expr (desc : O.Expr.desc) : O.Expr.t = { desc = desc; range = in_.range; type_ = in_.type_  } in
+  let create_expr (desc : O.Expr.desc) : O.Expr.t =
+    { desc; range = in_.range; type_ = in_.type_ }
+  in
   match binders with
   | [] -> assert false
   | [ binder ] -> compile_binder binder, in_
   | binders ->
     let var = compile_var (Value_var.fresh ~loc:dummy_loc ()) in
     let binders = List.map binders ~f:compile_binder in
-    ( (var, {desc = Tuple (O.Row.Node (List.map binders ~f:(fun (var, ty) -> O.Row.Leaf (None, ty)))); range = dummy_range })
+    ( ( var
+      , { desc =
+            Tuple
+              (O.Row.Node (List.map binders ~f:(fun (var, ty) -> O.Row.Leaf (None, ty))))
+        ; range = dummy_range
+        } )
     , create_expr
-      @@ Let_tuple_in { components = List.map binders ~f:fst; rhs = create_expr @@ Variable var; in_ } )
+      @@ Let_tuple_in
+           { components = List.map binders ~f:fst
+           ; rhs = create_expr @@ Variable var
+           ; in_
+           } )
 
 and compile_inline_michelson (code, args') =
-  let args_compiled = List.map args' ~f:(
-      fun e -> (
-        compile_expression e
-    )) in
-    let args_ty = List.map args' ~f:(
-      fun e -> (
+  let args_compiled = List.map args' ~f:(fun e -> compile_expression e) in
+  let args_ty =
+    List.map args' ~f:(fun e ->
         Mini_c.PP.type_expression Format.str_formatter e.type_expression;
-        compile_type_expression e.type_expression;
-    )) in
-    let wipe_locations l e =
-      Tezos_micheline.Micheline.(inject_locations (fun _ -> l) (strip_locations e))
-    in
-    let code = (List.map ~f:(wipe_locations (())) code) in
-    let used = ref [] in
-    let replace m =
-      let open Tezos_micheline.Micheline in
-      match m with
-      | Prim (_, s, [], [ id ])
-        when String.equal "typeopt" s && String.is_prefix ~prefix:"$" id ->
-        let id = String.chop_prefix_exn ~prefix:"$" id in
-        let id = Int.of_string id in
-        used := id :: !used;
-        (match List.nth args_ty id with
-        | Some (prim) ->
-          (match (Lltz_codegen.convert_type prim) with
-          | (Prim (_, Michelson.Ast.Prim.T Michelson.Ast.Prim.Type.Option, [ t ], _))  
-            -> Tezos_micheline.Micheline.map_node (fun _ -> ()) (fun prim -> Michelson.Ast.Prim.to_string prim) t
-          | _ -> raise_s [%message "could not resolve (typeopt $)" (id : int)])
+        compile_type_expression e.type_expression)
+  in
+  let wipe_locations l e =
+    Tezos_micheline.Micheline.(inject_locations (fun _ -> l) (strip_locations e))
+  in
+  let code = List.map ~f:(wipe_locations ()) code in
+  let used = ref [] in
+  let replace m =
+    let open Tezos_micheline.Micheline in
+    match m with
+    | Prim (_, s, [], [ id ])
+      when String.equal "typeopt" s && String.is_prefix ~prefix:"$" id ->
+      let id = String.chop_prefix_exn ~prefix:"$" id in
+      let id = Int.of_string id in
+      used := id :: !used;
+      (match List.nth args_ty id with
+      | Some prim ->
+        (match Lltz_codegen.convert_type prim with
+        | Prim (_, Michelson.Ast.Prim.T Michelson.Ast.Prim.Type.Option, [ t ], _) ->
+          Tezos_micheline.Micheline.map_node
+            (fun _ -> ())
+            (fun prim -> Michelson.Ast.Prim.to_string prim)
+            t
         | _ -> raise_s [%message "could not resolve (typeopt $)" (id : int)])
-      | Prim (_, s, [], [ id ])
-        when String.equal "type" s && String.is_prefix ~prefix:"$" id ->
-        let id = String.chop_prefix_exn ~prefix:"$" id in
-        let id = Int.of_string id in
-        used := id :: !used;
-        (match List.nth args_ty id with
-        | None -> raise_s [%message "could not resolve (type $)" (id : int)]
-        | Some (t) -> 
-          Tezos_micheline.Micheline.map_node (fun _ -> ()) (fun prim -> Michelson.Ast.Prim.to_string prim) (Lltz_codegen.convert_type t))
-      | Prim (_, s, [], [ id ])
-        when String.equal "litstr" s && String.is_prefix ~prefix:"$" id ->
-        let id = String.chop_prefix_exn ~prefix:"$" id in
-        let id = Int.of_string id in
-        used := id :: !used;
-        (match List.nth args_compiled id with
-        | Some ({desc = Const(O.Expr.String (s)); _}) -> String ((), s)
-        | _ -> raise_s [%message "could not resolve (litstr $)" (id : int)])
-      | Prim (_, s, [], [ id ])
-        when String.equal "codestr" s && String.is_prefix ~prefix:"$" id ->
-        let id = String.chop_prefix_exn ~prefix:"$" id in
-        let id = Int.of_string id in
-        used := id :: !used;
-        (match List.nth args_compiled id with
-        | Some ({desc = Const(O.Expr.String (s)); _}) ->
-          let open Tezos_micheline in
-          let code = s in
-          let code, errs = Micheline_parser.tokenize code in
+      | _ -> raise_s [%message "could not resolve (typeopt $)" (id : int)])
+    | Prim (_, s, [], [ id ])
+      when String.equal "type" s && String.is_prefix ~prefix:"$" id ->
+      let id = String.chop_prefix_exn ~prefix:"$" id in
+      let id = Int.of_string id in
+      used := id :: !used;
+      (match List.nth args_ty id with
+      | None -> raise_s [%message "could not resolve (type $)" (id : int)]
+      | Some t ->
+        Tezos_micheline.Micheline.map_node
+          (fun _ -> ())
+          (fun prim -> Michelson.Ast.Prim.to_string prim)
+          (Lltz_codegen.convert_type t))
+    | Prim (_, s, [], [ id ])
+      when String.equal "litstr" s && String.is_prefix ~prefix:"$" id ->
+      let id = String.chop_prefix_exn ~prefix:"$" id in
+      let id = Int.of_string id in
+      used := id :: !used;
+      (match List.nth args_compiled id with
+      | Some { desc = Const (O.Expr.String s); _ } -> String ((), s)
+      | _ -> raise_s [%message "could not resolve (litstr $)" (id : int)])
+    | Prim (_, s, [], [ id ])
+      when String.equal "codestr" s && String.is_prefix ~prefix:"$" id ->
+      let id = String.chop_prefix_exn ~prefix:"$" id in
+      let id = Int.of_string id in
+      used := id :: !used;
+      (match List.nth args_compiled id with
+      | Some { desc = Const (O.Expr.String s); _ } ->
+        let open Tezos_micheline in
+        let code = s in
+        let code, errs = Micheline_parser.tokenize code in
+        (match errs with
+        | _ :: _ -> raise_s [%message "could not parse raw michelson"]
+        | [] ->
+          let code, errs = Micheline_parser.parse_expression ~check:false code in
           (match errs with
-          | _ :: _ ->
-            raise_s [%message "could not parse raw michelson"]
+          | _ :: _ -> raise_s [%message "could not parse raw michelson"]
           | [] ->
-            let code, errs = Micheline_parser.parse_expression ~check:false code in
-            (match errs with
-            | _ :: _ ->
-              raise_s [%message "could not parse raw michelson"]
-            | [] ->
-              let code = Micheline.strip_locations code in
-              (* hmm *)
-              let code = Micheline.inject_locations (fun _ -> Location.generated) code in
-              map_node (fun _ -> ()) (fun x -> x) code))
-        | _ -> raise_s [%message "could not resolve (codestr $)" (id : int)])
-      | Prim (a, b, c, d) ->
-        let open Tezos_micheline.Micheline in
-        let f arg (c, d) =
-          match arg with
-          | Prim (_, s, [], [ id ])
-            when String.equal "annot" s && String.is_prefix ~prefix:"$" id ->
-            let id = String.chop_prefix_exn ~prefix:"$" id in
-            let id = Int.of_string id in
-            used := id :: !used;
-            let annot =
-              match List.nth args_compiled id with
-              | Some ({desc = Const(O.Expr.String (s)); _}) -> s
-              | _ -> raise_s [%message "could not resolve (annot $)" (id : int)]
-            in
-            c, annot :: d
-          | m -> m :: c, d
-        in
-        let c, d = List.fold_right ~f ~init:([], d) c in
-        Prim (a, b, c, d)
-      | m -> m
-    in
-    let code = List.map ~f:(Tezos_utils.Michelson.map replace) code in
-    let args' =
-      List.filter_mapi
-        ~f:(fun i v ->
-          if not (List.mem !used i ~equal:Stdlib.( = )) then Some v else None)
-        args'
-    in
-    let code = (List.map ~f:(wipe_locations (dummy_loc)) code) in
-    let micheline = compile_micheline_seq code in
-    let args = List.map args' ~f:compile_expression in
-    micheline, args
+            let code = Micheline.strip_locations code in
+            (* hmm *)
+            let code = Micheline.inject_locations (fun _ -> Location.generated) code in
+            map_node (fun _ -> ()) (fun x -> x) code))
+      | _ -> raise_s [%message "could not resolve (codestr $)" (id : int)])
+    | Prim (a, b, c, d) ->
+      let open Tezos_micheline.Micheline in
+      let f arg (c, d) =
+        match arg with
+        | Prim (_, s, [], [ id ])
+          when String.equal "annot" s && String.is_prefix ~prefix:"$" id ->
+          let id = String.chop_prefix_exn ~prefix:"$" id in
+          let id = Int.of_string id in
+          used := id :: !used;
+          let annot =
+            match List.nth args_compiled id with
+            | Some { desc = Const (O.Expr.String s); _ } -> s
+            | _ -> raise_s [%message "could not resolve (annot $)" (id : int)]
+          in
+          c, annot :: d
+        | m -> m :: c, d
+      in
+      let c, d = List.fold_right ~f ~init:([], d) c in
+      Prim (a, b, c, d)
+    | m -> m
+  in
+  let code = List.map ~f:(Tezos_utils.Michelson.map replace) code in
+  let args' =
+    List.filter_mapi
+      ~f:(fun i v -> if not (List.mem !used i ~equal:Stdlib.( = )) then Some v else None)
+      args'
+  in
+  let code = List.map ~f:(wipe_locations dummy_loc) code in
+  let micheline = compile_micheline_seq code in
+  let args = List.map args' ~f:compile_expression in
+  micheline, args

--- a/nix/haskell-overlay.nix
+++ b/nix/haskell-overlay.nix
@@ -1,6 +1,5 @@
 final: prev:
-with prev;
-{
+with prev; {
   libsodium = libsodium.overrideAttrs (with libsodium; rec {
     version = "1.0.18";
     src = final.fetchurl {

--- a/nix/ligo.nix
+++ b/nix/ligo.nix
@@ -7,7 +7,7 @@
   tree-sitter-typescript,
   grace,
   lltz,
-  libiconv
+  libiconv,
 }: let
   inherit (pkgs) darwin ocamlPackages python3Packages coq_8_13 rustc cargo rustPlatform;
 in

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -13,8 +13,8 @@ with prev; {
               url = "https://github.com/mirage/ocaml-cohttp/releases/download/v${version}/cohttp-${version}.tbz";
               hash = "sha256-9eJz08Lyn/R71+Ftsj4fPWzQGkC+ACCJhbxDTIjUV2s=";
             };
-            buildInputs = [ jsonm ppx_sexp_conv ];
-            propagatedBuildInputs = [ base64 re stringext uri-sexp ];
+            buildInputs = [jsonm ppx_sexp_conv];
+            propagatedBuildInputs = [base64 re stringext uri-sexp];
           };
 
           tezt = buildDunePackage rec {
@@ -30,8 +30,8 @@ with prev; {
               hash = "sha256-1Cl/GOB+MDPJIl/6600PLTSL+vCYcAZGjedd6hr7rJw=";
             };
 
-            propagatedBuildInputs = [ clap ezjsonm lwt re ];
-          };  
+            propagatedBuildInputs = [clap ezjsonm lwt re];
+          };
 
           # TODO: odoc-parser and ocamlformat are issues with nix-ocaml
           odoc-parser = prev.odoc-parser.overrideAttrs (prev: {

--- a/nix/tree-sitter-typescript.nix
+++ b/nix/tree-sitter-typescript.nix
@@ -1,10 +1,9 @@
 {
-stdenv
-, lib
-, fetchFromGitHub
-, tree-sitter
-}:
-let 
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  tree-sitter,
+}: let
   version = "0.22.5";
 
   src = fetchFromGitHub {
@@ -13,22 +12,16 @@ let
     rev = "198d03553f43a45b92ac5d0ee167db3fec6a6fd6";
     hash = "sha256-U597+o8gakd4nU9H2FE2aVhGqSG/eRh6BUhtEmwMzrU=";
   };
-
 in
+  stdenv.mkDerivation {
+    pname = "tree-sitter-typescript";
+    inherit src version;
 
+    nativeBuildInputs = [tree-sitter];
 
-stdenv.mkDerivation {
-  pname = "tree-sitter-typescript";
-  inherit src version;
-  
-  nativeBuildInputs = [ tree-sitter ];
+    configurePhase = ''
+      cd typescript
+    '';
 
-
-  configurePhase = ''
-    cd typescript
-  '';
-
-
-
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
-}
+    makeFlags = ["PREFIX=${placeholder "out"}"];
+  }

--- a/src/bin/cli.ml
+++ b/src/bin/cli.ml
@@ -590,6 +590,7 @@ let function_body =
   let doc = "compile expression as a function body" in
   flag ~doc name no_arg
 
+
 let lltz_ir =
   let open Command.Param in
   let name = "--lltz-ir" in

--- a/src/main/compile/of_core.ml
+++ b/src/main/compile/of_core.ml
@@ -166,10 +166,7 @@ let list_mod_declarations (m : Ast_core.program) : Module_var.t list =
       | D_import (Import_all_as { module_str; _ }) ->
         Module_var.of_input_var ~loc:el.location module_str :: prev
       | D_import (Import_selected _) -> prev
-      | D_value _
-      | D_irrefutable_match _
-      | D_type _
-      | D_signature _
-      | D_module_include _ -> prev)
+      | D_value _ | D_irrefutable_match _ | D_type _ | D_signature _ | D_module_include _
+        -> prev)
     ~init:[]
     m

--- a/src/main/compile/of_mini_c.ml
+++ b/src/main/compile/of_mini_c.ml
@@ -4,7 +4,6 @@ open Proto_alpha_utils
 open Trace
 open! Stacking
 open Tezos_micheline
-
 open Ligo_lltz_codegen
 open Lltz_codegen
 
@@ -62,49 +61,72 @@ let compile_contract ~raise
  fun ~options e_contract ->
   let open Lwt.Let_syntax in
   let input_ty, contract = optimize_for_contract ~raise options e_contract in
-
-  let optimize = 
-    function expr -> 
-        Self_michelson.optimize
-          ~experimental_disable_optimizations_for_debugging:
-            options.backend.experimental_disable_optimizations_for_debugging
-          ~has_comment:(has_comment options)
-          expr
+  let optimize = function
+    | expr ->
+      Self_michelson.optimize
+        ~experimental_disable_optimizations_for_debugging:
+          options.backend.experimental_disable_optimizations_for_debugging
+        ~has_comment:(has_comment options)
+        expr
   in
   let%map expr =
-    if options.backend.lltz_ir then
-      let e_simplified = trace ~raise self_mini_c_tracer @@ Self_mini_c.all_expression options contract.body in
-
-      let expr_unoptimised = 
-        let (Var lltz_var, lltz_ty, lltz_body) = Ligo_lltz_codegen.compile_contract contract.binder input_ty e_simplified in
-        Lltz_codegen.compile_contract_to_micheline ~optimize:false lltz_var lltz_ty lltz_body [] in
-      let expr_unoptimised = Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr_unoptimised in 
-      
-      let expr_optimised = 
-        let (Var lltz_var, lltz_ty, lltz_body) = Ligo_lltz_codegen.compile_contract contract.binder input_ty e_simplified in
-        Lltz_codegen.compile_contract_to_micheline ~optimize:true lltz_var lltz_ty lltz_body [] in
-      let expr_optimised = Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr_optimised in 
-
-      let%bind size_optimised = Of_michelson.measure ~raise (expr_optimised) in
+    if options.backend.lltz_ir
+    then (
+      let e_simplified =
+        trace ~raise self_mini_c_tracer
+        @@ Self_mini_c.all_expression options contract.body
+      in
+      let expr_unoptimised =
+        let Var lltz_var, lltz_ty, lltz_body =
+          Ligo_lltz_codegen.compile_contract contract.binder input_ty e_simplified
+        in
+        Lltz_codegen.compile_contract_to_micheline
+          ~optimize:false
+          lltz_var
+          lltz_ty
+          lltz_body
+          []
+      in
+      let expr_unoptimised =
+        Micheline.map_node
+          (fun _ -> dummy)
+          (fun prim -> Michelson.Ast.Prim.to_string prim)
+          expr_unoptimised
+      in
+      let expr_optimised =
+        let Var lltz_var, lltz_ty, lltz_body =
+          Ligo_lltz_codegen.compile_contract contract.binder input_ty e_simplified
+        in
+        Lltz_codegen.compile_contract_to_micheline
+          ~optimize:true
+          lltz_var
+          lltz_ty
+          lltz_body
+          []
+      in
+      let expr_optimised =
+        Micheline.map_node
+          (fun _ -> dummy)
+          (fun prim -> Michelson.Ast.Prim.to_string prim)
+          expr_optimised
+      in
+      let%bind size_optimised = Of_michelson.measure ~raise expr_optimised in
       let%bind size_unoptimised = Of_michelson.measure ~raise expr_unoptimised in
-
       (* Assert that size with lltz is smaller than without *)
-      if size_optimised > size_unoptimised then
-        assert false
-      else
-        Lwt.return expr_optimised
-    else
+      if size_optimised > size_unoptimised
+      then assert false
+      else Lwt.return expr_optimised)
+    else (
       let de_bruijn =
         trace ~raise scoping_tracer @@ Scoping.translate_closed_function contract input_ty
       in
       let%bind expr = Stacking.Program.compile_function_body de_bruijn in
       let optimised_expr = optimize expr in
-
-      Lwt.return optimised_expr
+      Lwt.return optimised_expr)
   in
-    let expr_ty = compile_type e_contract.type_expression in
-    let expr_ty = dummy_locations expr_ty in
-    ({ expr_ty; expr } : Stacking.Program.compiled_expression)
+  let expr_ty = compile_type e_contract.type_expression in
+  let expr_ty = dummy_locations expr_ty in
+  ({ expr_ty; expr } : Stacking.Program.compiled_expression)
 
 
 let compile_view ~raise
@@ -148,46 +170,58 @@ let compile_view ~raise
 let compile_expression ~raise
     : options:Compiler_options.t -> expression -> compiled_expression Lwt.t
   =
-    fun ~options e ->
-      let e = trace ~raise self_mini_c_tracer @@ Self_mini_c.all_expression options e in
-      let open Lwt.Let_syntax in
-
-      let optimize = 
-        function expr -> 
-            Self_michelson.optimize
-              ~experimental_disable_optimizations_for_debugging:
-                options.backend.experimental_disable_optimizations_for_debugging
-              ~has_comment:(has_comment options)
-              expr
+ fun ~options e ->
+  let e = trace ~raise self_mini_c_tracer @@ Self_mini_c.all_expression options e in
+  let open Lwt.Let_syntax in
+  let optimize = function
+    | expr ->
+      Self_michelson.optimize
+        ~experimental_disable_optimizations_for_debugging:
+          options.backend.experimental_disable_optimizations_for_debugging
+        ~has_comment:(has_comment options)
+        expr
+  in
+  let%map expr =
+    if options.backend.lltz_ir
+    then (
+      let expr_lltz_opt =
+        Lltz_codegen.compile_to_micheline
+          ~optimize:true
+          (Ligo_lltz_codegen.compile_expression e)
+          []
       in
-
-      let%map expr = 
-        if options.backend.lltz_ir then
-          let expr_lltz_opt = Lltz_codegen.compile_to_micheline ~optimize:true (Ligo_lltz_codegen.compile_expression e) [] in
-          let expr_optimised =
-            Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr_lltz_opt
-          in
-
-          let expr_lltz_unopt = Lltz_codegen.compile_to_micheline ~optimize:false (Ligo_lltz_codegen.compile_expression e) [] in
-          let expr_unoptimised =
-            Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr_lltz_unopt
-          in
-
-          let%bind size_optimised = Of_michelson.measure ~raise expr_optimised in
-          let%bind size_unoptimised = Of_michelson.measure ~raise expr_unoptimised in
-
-          (* Assert that size with lltz michelson optimisations is smaller than without *)
-          if size_optimised > size_unoptimised then
-            assert false
-          else
-            Lwt.return expr_optimised
-        else
-          let expr = trace ~raise scoping_tracer @@ Scoping.translate_expression e [] in
-          let%bind expr = Stacking.Program.compile_expr [] expr in
-          Lwt.return (optimize expr)
+      let expr_optimised =
+        Micheline.map_node
+          (fun _ -> dummy)
+          (fun prim -> Michelson.Ast.Prim.to_string prim)
+          expr_lltz_opt
       in
-        let expr_ty = compile_type e.type_expression in
-        (({ expr_ty; expr } : Program.compiled_expression))
+      let expr_lltz_unopt =
+        Lltz_codegen.compile_to_micheline
+          ~optimize:false
+          (Ligo_lltz_codegen.compile_expression e)
+          []
+      in
+      let expr_unoptimised =
+        Micheline.map_node
+          (fun _ -> dummy)
+          (fun prim -> Michelson.Ast.Prim.to_string prim)
+          expr_lltz_unopt
+      in
+      let%bind size_optimised = Of_michelson.measure ~raise expr_optimised in
+      let%bind size_unoptimised = Of_michelson.measure ~raise expr_unoptimised in
+      (* Assert that size with lltz michelson optimisations is smaller than without *)
+      if size_optimised > size_unoptimised
+      then assert false
+      else Lwt.return expr_optimised)
+    else (
+      let expr = trace ~raise scoping_tracer @@ Scoping.translate_expression e [] in
+      let%bind expr = Stacking.Program.compile_expr [] expr in
+      Lwt.return (optimize expr))
+  in
+  let expr_ty = compile_type e.type_expression in
+  ({ expr_ty; expr } : Program.compiled_expression)
+
 
 let compile_expression_function ~raise
     : options:Compiler_options.t -> expression -> compiled_expression Lwt.t

--- a/src/main/interpreter/common/michelson_to_value.ml
+++ b/src/main/interpreter/common/michelson_to_value.ml
@@ -323,8 +323,8 @@ let rec decompile_to_untyped_value ~(raise : _ Trace.raise) ~bigmaps
       }
   | ( Prim (loct, "ticket", [ ty_ticked ], _)
     , Prim (_, "Pair", [ addr; Prim (_, "Pair", [ vt; amt ], _) ], _) )
-  | ( Prim (loct, "ticket", [ ty_ticked ], _)
-    , Prim (_, "Ticket", [ addr; _; vt; amt ], _)) ->
+  | Prim (loct, "ticket", [ ty_ticked ], _), Prim (_, "Ticket", [ addr; _; vt; amt ], _)
+    ->
     (* note: the above Pair structure (pair addr (pair vt amt)) comes from tezos protocol *)
     let addr =
       Ligo_interpreter.Combinators.v_address

--- a/src/passes/10-checking/cmi.mli
+++ b/src/passes/10-checking/cmi.mli
@@ -12,7 +12,8 @@ val get_deps : t -> Filename.t list
 module Serialized : sig
   val input : Filename.t -> (t * crc) option
   val output : t -> unit
-  (** Makes cmi path from original file path *)
+
+  (* Makes cmi path from original file path *)
   val make_path : Filename.t -> Filename.t
   val compute_crc : t -> crc
 end

--- a/src/passes/10-checking/cmo.mli
+++ b/src/passes/10-checking/cmo.mli
@@ -7,6 +7,7 @@ type t =
 module Serialized : sig
   val input : Filename.t -> t option
   val output : t -> unit
-  (** Makes cmo path from original file path *)
+
+  (* Makes cmo path from original file path *)
   val make_path : Filename.t -> Filename.t
 end

--- a/src/passes/10-checking/persistent_env.ml
+++ b/src/passes/10-checking/persistent_env.ml
@@ -10,6 +10,7 @@ type t =
 let empty : t =
   { cmis = Filename.Map.empty; path_tbl = Module_map.empty; virtual_env = [] }
 
+
 let verify_deps : t -> (Filename.t * Cmi.crc) list -> bool =
  fun { cmis; _ } deps ->
   List.for_all
@@ -19,21 +20,33 @@ let verify_deps : t -> (Filename.t * Cmi.crc) list -> bool =
       | Some (_, crc') -> Md5.equal crc crc')
     deps
 
-type key = Module of Module_var.t | File of Filename.t
+
+type key =
+  | Module of Module_var.t
+  | File of Filename.t
 
 let find_cmi : t -> key -> Cmi.t * Cmi.crc =
- fun { cmis; path_tbl; _ } key -> match key with
- | Module mv -> let path = Map.find_exn path_tbl mv in Map.find_exn cmis path
- | File f -> Map.find_exn cmis f
+ fun { cmis; path_tbl; _ } key ->
+  match key with
+  | Module mv ->
+    let path = Map.find_exn path_tbl mv in
+    Map.find_exn cmis path
+  | File f -> Map.find_exn cmis f
 
-let compute_cmi : t -> Filename.t -> Filename.t list -> Ast_typed.signature -> Cmi.t * Cmi.crc =
+
+let compute_cmi
+    : t -> Filename.t -> Filename.t list -> Ast_typed.signature -> Cmi.t * Cmi.crc
+  =
  fun ({ cmis; _ } as env) path imports sign ->
   let imports =
-    List.map ~f:(fun filename -> filename, Tuple2.get2 @@ find_cmi env (File filename)) imports
+    List.map
+      ~f:(fun filename -> filename, Tuple2.get2 @@ find_cmi env (File filename))
+      imports
   in
   let cmi = Cmi.{ path; sign; imports } in
   let crc = Cmi.Serialized.compute_crc cmi in
   cmi, crc
+
 
 let add_signature
     : t -> Module_var.t -> Filename.t -> Filename.t list -> Ast_typed.signature -> t
@@ -43,6 +56,7 @@ let add_signature
   let cmis = Map.set cmis ~key:path ~data:(cmi, crc) in
   let path_tbl = Map.set path_tbl ~key:m ~data:path in
   { cmis; path_tbl; virtual_env }
+
 
 let add_cmi : t -> Module_var.t -> Filename.t -> Cmi.t -> Cmi.crc -> t =
  fun { cmis; path_tbl; virtual_env } m path cmi crc ->

--- a/src/passes/10-checking/untyper.ml
+++ b/src/passes/10-checking/untyper.ml
@@ -344,8 +344,7 @@ and untype_declaration ~raise =
     | D_signature ds ->
       let ds = untype_declaration_signature ~raise ds in
       return @@ D_signature ds
-    | D_import decl ->
-      return @@ D_import decl
+    | D_import decl -> return @@ D_import decl
 
 
 and untype_decl ~raise : O.decl -> I.decl =

--- a/src/passes/15-self_mini_c/uncurry.ml
+++ b/src/passes/15-self_mini_c/uncurry.ml
@@ -180,9 +180,7 @@ let rec uncurry_in_expression (f : Value_var.t) (depth : int) (expr : expression
   let self_binder vars e =
     if List.mem ~equal:Value_var.equal vars f then e else uncurry_in_expression f depth e
   in
-  let return e' = 
-    { expr with content = e' } 
-  in
+  let return e' = { expr with content = e' } in
   let return_id = expr in
   match expr.content with
   | E_application app ->
@@ -192,13 +190,14 @@ let rec uncurry_in_expression (f : Value_var.t) (depth : int) (expr : expression
       (* the interesting part... *)
       let args = comb_expr args in
       let args = self args in
-      let lamb = {
-        lamb with 
-        type_expression = {
-          lamb.type_expression with 
-          type_content = T_function (args.type_expression, expr.type_expression)
-          }
-      } in
+      let lamb =
+        { lamb with
+          type_expression =
+            { lamb.type_expression with
+              type_content = T_function (args.type_expression, expr.type_expression)
+            }
+        }
+      in
       return (E_application (lamb, args)))
     else (
       let lamb, args = app in

--- a/src/stages/4-ast_core/ligo_dep_cameligo.ml
+++ b/src/stages/4-ast_core/ligo_dep_cameligo.ml
@@ -19,18 +19,14 @@ and collect_from_decl ({ deps; scope } as acc) decl =
   match Location.unwrap decl with
   | Types.D_module decl -> collect_from_module_decl acc decl
   | D_signature sig_decl ->
-    let { deps; _ } =
-      collect_from_signature_decl acc sig_decl
-    in
+    let { deps; _ } = collect_from_signature_decl acc sig_decl in
     { acc with deps }
   | D_value decl ->
     let { deps; _ } = collect_from_value acc decl in
     { acc with deps }
   | D_irrefutable_match { pattern; expr; attr = _ } ->
     let { deps; _ } = collect_from_expr acc expr in
-    let { deps; _ } =
-      collect_from_pattern { deps; scope } pattern
-    in
+    let { deps; _ } = collect_from_pattern { deps; scope } pattern in
     { acc with deps }
   | D_type { type_expr; type_binder = _; type_attr = _ } ->
     let { deps; _ } = collect_from_ty_expr acc type_expr in
@@ -50,17 +46,15 @@ and collect_from_signature_decl
   let { deps; _ } = collect_from_signature_expr acc signature in
   { acc with deps }
 
+
 (** Collect external deps from signature expr. Singleton paths
     cannot be external. Other paths are external iff the
     first item of the path is external *)
-and collect_from_signature_expr
-    ({ deps; scope } as acc)
-    sig_expr
-  =
+and collect_from_signature_expr ({ deps; scope } as acc) sig_expr =
   let deps =
     match Location.unwrap sig_expr with
     (* It's not possible to be external being the module type *)
-    | Types.S_path (mvar :: []) -> deps
+    | Types.S_path [ mvar ] -> deps
     (* Only the first module var from the path could be external *)
     | S_path (mvar :: _) -> add_to_deps acc mvar
     | S_sig signature ->
@@ -73,10 +67,7 @@ and collect_from_signature_expr
 
 (** Collects external deps from signature.
     Built up scope gets discarded after folding it. *)
-and collect_from_signature
-    ({ deps; scope } as acc)
-    Types.{ items }
-  =
+and collect_from_signature ({ deps; scope } as acc) Types.{ items } =
   (* We have to discard scope accumulated inside signature *)
   let { deps; _ } = List.fold items ~init:acc ~f:collect_from_sig_item in
   { acc with deps }
@@ -124,8 +115,7 @@ and collect_from_module_decl
 (** Collects external deps from `mod in` expression.
     It evaluates module expression in previous scope
     and adds its binder to the resulting scope *)
-and collect_from_mod_in ({ deps; scope } as acc) binder mod_expr
-  =
+and collect_from_mod_in ({ deps; scope } as acc) binder mod_expr =
   let { deps; _ } = collect_from_mod_expr acc mod_expr in
   { deps; scope = Set.add scope binder }
 
@@ -158,17 +148,13 @@ and collect_from_value
 
 
 (** Collects external deps from ty expr. *)
-and collect_from_ty_expr
-    ({ deps; scope } as acc)
-    { type_content; location = _ }
-  =
+and collect_from_ty_expr ({ deps; scope } as acc) { type_content; location = _ } =
   match type_content with
   | T_variable _ -> acc
   | T_constant (_, _) -> acc
   | T_contract_parameter (h :: tl) ->
     let deps =
-      List.fold (h :: tl) ~init:deps ~f:(fun deps m ->
-          add_to_deps { deps; scope } m)
+      List.fold (h :: tl) ~init:deps ~f:(fun deps m -> add_to_deps { deps; scope } m)
     in
     { acc with deps }
   | T_sum { fields; _ } ->
@@ -176,15 +162,13 @@ and collect_from_ty_expr
       List.fold
         (Map.to_alist fields)
         ~init:acc
-        ~f:(fun ({ deps; scope } as acc) (_, ty) ->
-          collect_from_ty_expr acc ty)
+        ~f:(fun ({ deps; scope } as acc) (_, ty) -> collect_from_ty_expr acc ty)
     in
     { acc with deps }
   | T_union union ->
     let { deps; _ }, _ =
       Union.fold_map
-        (fun ({ deps; scope } as acc) ty ->
-          collect_from_ty_expr acc ty, ty)
+        (fun ({ deps; scope } as acc) ty -> collect_from_ty_expr acc ty, ty)
         acc
         union
     in
@@ -194,8 +178,7 @@ and collect_from_ty_expr
       List.fold
         (Record.to_list fields)
         ~init:acc
-        ~f:(fun ({ deps; scope } as acc) (_, ty) ->
-          collect_from_ty_expr acc ty)
+        ~f:(fun ({ deps; scope } as acc) (_, ty) -> collect_from_ty_expr acc ty)
     in
     { acc with deps }
   | T_arrow { type1; type2; param_names = _ } ->
@@ -205,10 +188,7 @@ and collect_from_ty_expr
   | T_app { type_operator = { module_path = h :: _; element = _ }; arguments } ->
     let deps = add_to_deps acc h in
     let { deps; _ } =
-      List.fold
-        arguments
-        ~init:{ acc with deps }
-        ~f:(fun ({ deps; scope } as acc) ty ->
+      List.fold arguments ~init:{ acc with deps } ~f:(fun ({ deps; scope } as acc) ty ->
           collect_from_ty_expr acc ty)
     in
     { acc with deps }
@@ -227,10 +207,7 @@ and collect_from_ty_expr
 (** Collects external deps from expression.
     Only thing affecting local expression scope is `E_mod_in`.
     Other items are used only to collect deps *)
-and collect_from_expr
-    ({ deps; scope } as acc)
-    { expression_content; location = _ }
-  =
+and collect_from_expr ({ deps; scope } as acc) { expression_content; location = _ } =
   match expression_content with
   | E_variable _ -> acc
   | E_literal _ -> acc
@@ -274,31 +251,19 @@ and collect_from_expr
       } ->
     let Binder.{ ascr; var = _ } = binder.binder in
     let { deps; _ } = collect_from_expr acc result in
-    let { deps; _ } =
-      collect_from_ty_expr { acc with deps } output_type
-    in
-    let { deps; _ } =
-      collect_from_ty_expr { acc with deps } ascr
-    in
-    let { deps; _ } =
-      collect_from_ty_expr { acc with deps } fun_type
-    in
+    let { deps; _ } = collect_from_ty_expr { acc with deps } output_type in
+    let { deps; _ } = collect_from_ty_expr { acc with deps } ascr in
+    let { deps; _ } = collect_from_ty_expr { acc with deps } fun_type in
     { acc with deps }
   | E_type_abstraction { result; type_binder = _ } -> collect_from_expr acc result
   | E_let_in { let_binder; rhs; let_result; attributes = _ } ->
     let { deps; _ } = collect_from_expr acc rhs in
-    let { deps; _ } =
-      collect_from_expr { acc with deps } let_result
-    in
-    let { deps; _ } =
-      collect_from_pattern { acc with deps } let_binder
-    in
+    let { deps; _ } = collect_from_expr { acc with deps } let_result in
+    let { deps; _ } = collect_from_pattern { acc with deps } let_binder in
     { acc with deps }
   | E_type_in { rhs; let_result; type_binder = _ } ->
     let { deps; _ } = collect_from_expr acc let_result in
-    let { deps; _ } =
-      collect_from_ty_expr { deps; scope } rhs
-    in
+    let { deps; _ } = collect_from_ty_expr { deps; scope } rhs in
     { acc with deps }
   | E_raw_code { code; language = _ } ->
     let { deps; _ } = collect_from_expr acc code in
@@ -319,28 +284,19 @@ and collect_from_expr
     { acc with deps }
   | E_record l ->
     let { deps; _ } =
-      List.fold
-        (Record.to_list l)
-        ~init:acc
-        ~f:(fun ({ deps; scope } as acc) (_, expr) ->
+      List.fold (Record.to_list l) ~init:acc ~f:(fun ({ deps; scope } as acc) (_, expr) ->
           collect_from_expr acc expr)
     in
     { acc with deps }
   | E_tuple (h :: tl) ->
     let { deps; _ } =
-      List.fold
-        (h :: tl)
-        ~init:acc
-        ~f:(fun ({ deps; scope } as acc) expr ->
+      List.fold (h :: tl) ~init:acc ~f:(fun ({ deps; scope } as acc) expr ->
           collect_from_expr acc expr)
     in
     { acc with deps }
   | E_array l ->
     let { deps; _ } =
-      List.fold
-        l
-        ~init:acc
-        ~f:(fun ({ deps; scope } as acc) expr ->
+      List.fold l ~init:acc ~f:(fun ({ deps; scope } as acc) expr ->
           match expr with
           | Expr_entry expr -> collect_from_expr acc expr
           | Rest_entry expr -> collect_from_expr acc expr)
@@ -348,10 +304,7 @@ and collect_from_expr
     { acc with deps }
   | E_array_as_list l ->
     let { deps; _ } =
-      List.fold
-        l
-        ~init:acc
-        ~f:(fun ({ deps; scope } as acc) expr ->
+      List.fold l ~init:acc ~f:(fun ({ deps; scope } as acc) expr ->
           match expr with
           | Expr_entry expr -> collect_from_expr acc expr
           | Rest_entry expr -> collect_from_expr acc expr)
@@ -362,26 +315,19 @@ and collect_from_expr
     { acc with deps }
   | E_update { struct_; update; path = _ } ->
     let { deps; _ } = collect_from_expr acc update in
-    let { deps; _ } =
-      collect_from_expr { acc with deps } struct_
-    in
+    let { deps; _ } = collect_from_expr { acc with deps } struct_ in
     { acc with deps }
   | E_ascription { anno_expr; type_annotation } ->
     let { deps; _ } = collect_from_expr acc anno_expr in
-    let { deps; _ } =
-      collect_from_ty_expr { acc with deps } type_annotation
-    in
+    let { deps; _ } = collect_from_ty_expr { acc with deps } type_annotation in
     { acc with deps }
   | E_module_accessor { module_path = []; element = _ } -> acc
-  | E_module_accessor { module_path = h :: _; element = _ } -> { acc with deps = add_to_deps acc h }
+  | E_module_accessor { module_path = h :: _; element = _ } ->
+    { acc with deps = add_to_deps acc h }
   | E_let_mut_in { let_binder; rhs; let_result; attributes = _ } ->
     let { deps; _ } = collect_from_expr acc rhs in
-    let { deps; _ } =
-      collect_from_expr { acc with deps } let_result
-    in
-    let { deps; _ } =
-      collect_from_pattern { acc with deps } let_binder
-    in
+    let { deps; _ } = collect_from_expr { acc with deps } let_result in
+    let { deps; _ } = collect_from_pattern { acc with deps } let_binder in
     { acc with deps }
   | E_assign { expression; binder = { ascr; var = _ } } ->
     let { deps; _ } = collect_from_expr acc expression in
@@ -396,15 +342,11 @@ and collect_from_expr
     let { deps; _ } = collect_from_expr acc start in
     let { deps; _ } = collect_from_expr { acc with deps } final in
     let { deps; _ } = collect_from_expr { acc with deps } incr in
-    let { deps; _ } =
-      collect_from_expr { acc with deps } f_body
-    in
+    let { deps; _ } = collect_from_expr { acc with deps } f_body in
     { acc with deps }
   | E_for_each { collection; fe_body; fe_binder = _; collection_type = _ } ->
     let { deps; _ } = collect_from_expr acc collection in
-    let { deps; _ } =
-      collect_from_expr { acc with deps } fe_body
-    in
+    let { deps; _ } = collect_from_expr { acc with deps } fe_body in
     { acc with deps }
   | E_while { cond; body } ->
     let { deps; _ } = collect_from_expr acc cond in
@@ -443,6 +385,7 @@ and collect_from_pattern ({ deps; scope } as acc) pat =
       deps
   in
   { acc with deps }
+
 
 (* Accepts stdlib since stdlib modules shouldn't be considered external *)
 let dependencies ~std_lib prg =

--- a/src/stages/4-ast_core/types.ml
+++ b/src/stages/4-ast_core/types.ml
@@ -24,6 +24,7 @@ and type_expression =
   ; location : Location.t [@deriving.ignore] [@hash.ignore]
   }
 [@@deriving eq, compare, yojson, hash, bin_io]
+
 and type_expression_option = type_expression option [@@deriving eq, compare, yojson, hash]
 
 type ty_expr = type_expression [@@deriving eq, compare, yojson, hash, bin_io]
@@ -124,6 +125,5 @@ and signature_expr = signature_content Location.wrap
 
 type expr = expression [@@deriving eq, compare, yojson, hash, bin_io]
 type decl = declaration [@@deriving eq, compare, yojson, hash, bin_io]
-
 type module_ = decl list [@@deriving eq, compare, yojson, hash]
 type program = declaration list [@@deriving eq, compare, yojson, hash]

--- a/src/stages/5-ast_typed/types.ml
+++ b/src/stages/5-ast_typed/types.ml
@@ -158,9 +158,7 @@ and module_expr =
 [@@deriving equal, compare, yojson, hash]
 
 type expr = expression [@@deriving equal, compare, yojson, hash, bin_io]
-
 type decl = declaration [@@deriving equal, compare, yojson, hash, bin_io]
-
 type module_ = decl list [@@deriving equal, compare, yojson, hash, bin_io]
 
 type program =

--- a/src/stages/ligo_primitive/label.ml
+++ b/src/stages/ligo_primitive/label.ml
@@ -91,6 +91,7 @@ module Map = struct
     let alist = bin_read_t_aux bin_read_a buf ~pos_ref in
     of_alist_exn alist
 
+
   let __bin_read_t__ (bin_read_a : 'a Bin_prot.Read.reader) buf ~pos_ref =
     let f = __bin_read_t_aux__ bin_read_a buf ~pos_ref in
     fun n -> of_alist_exn @@ f n

--- a/src/test/test_helpers.ml
+++ b/src/test/test_helpers.ml
@@ -167,9 +167,11 @@ let type_file ~raise ?(st = "auto") f options =
   ignore st;
   Build.qualified_typed ~raise ~options (Build.Source_input.From_file f)
 
+
 let type_file_v2 ~raise ?(st = "auto") f options =
   ignore st;
   Build.qualified_typed_v2 ~raise ~options (Build.Source_input.From_file f)
+
 
 let core_file ~raise f options =
   Build.qualified_core ~raise ~options (Build.Source_input.From_file f)
@@ -197,7 +199,11 @@ let expression_to_core ~raise expression =
   core
 
 
-let pack_payload ?(options = options) ~raise (program : Ast_typed.program) (payload : Ast_unified.expr)
+let pack_payload
+    ?(options = options)
+    ~raise
+    (program : Ast_typed.program)
+    (payload : Ast_unified.expr)
     : bytes Lwt.t
   =
   let open Lwt.Let_syntax in
@@ -348,7 +354,12 @@ let run_typed_program_with_imperative_input_single
   =
   let open Lwt.Let_syntax in
   let%bind michelson_program, ty =
-    typed_program_with_imperative_input_to_michelson ~options:config_options ~raise program entry_point input
+    typed_program_with_imperative_input_to_michelson
+      ~options:config_options
+      ~raise
+      program
+      entry_point
+      input
   in
   let%map michelson_output =
     Ligo_run.Of_michelson.run_no_failwith
@@ -365,7 +376,9 @@ let run_typed_program_with_imperative_input_single
   in
   res
 
-let run_typed_program_with_imperative_input ~raise
+
+let run_typed_program_with_imperative_input
+    ~raise
     ?opt_options
     (program : Ast_typed.program)
     (entry_point : string)
@@ -373,10 +386,26 @@ let run_typed_program_with_imperative_input ~raise
     : Ast_core.expression Lwt.t
   =
   let open Lwt.Let_syntax in
-  let%bind res1 = run_typed_program_with_imperative_input_single ~raise ?options:opt_options ~config_options:options program entry_point input in
-  let%bind res2 = run_typed_program_with_imperative_input_single ~raise ?options:opt_options ~config_options:options_with_lltz program entry_point input in
+  let%bind res1 =
+    run_typed_program_with_imperative_input_single
+      ~raise
+      ?options:opt_options
+      ~config_options:options
+      program
+      entry_point
+      input
+  in
+  let%bind res2 =
+    run_typed_program_with_imperative_input_single
+      ~raise
+      ?options:opt_options
+      ~config_options:options_with_lltz
+      program
+      entry_point
+      input
+  in
   match res1, res2 with
-  | Runned_result.Success exp1, Runned_result.Success exp2 -> 
+  | Runned_result.Success exp1, Runned_result.Success exp2 ->
     let _ = Ast_core.Misc.assert_value_eq (exp1, exp2) in
     Lwt.return exp1
   | _ -> raise.error test_not_expected_to_fail
@@ -417,7 +446,9 @@ let run_typed_program_with_imperative_input_twice_single
   in
   res
 
-let run_typed_program_with_imperative_input_twice ~raise
+
+let run_typed_program_with_imperative_input_twice
+    ~raise
     ?opt_options
     ?(with_lltz = true)
     (program : Ast_typed.program)
@@ -428,31 +459,71 @@ let run_typed_program_with_imperative_input_twice ~raise
   =
   let open Lwt.Let_syntax in
   if with_lltz
-  then
-    let%bind res1 = run_typed_program_with_imperative_input_twice_single ~raise ?options:opt_options ~config_options:options program entry_point input1 input2 in
-    let%bind res2 = run_typed_program_with_imperative_input_twice_single ~raise ?options:opt_options ~config_options:options_with_lltz program entry_point input1 input2 in
+  then (
+    let%bind res1 =
+      run_typed_program_with_imperative_input_twice_single
+        ~raise
+        ?options:opt_options
+        ~config_options:options
+        program
+        entry_point
+        input1
+        input2
+    in
+    let%bind res2 =
+      run_typed_program_with_imperative_input_twice_single
+        ~raise
+        ?options:opt_options
+        ~config_options:options_with_lltz
+        program
+        entry_point
+        input1
+        input2
+    in
     match res1, res2 with
-    | Runned_result.Success exp1, Runned_result.Success exp2 -> 
+    | Runned_result.Success exp1, Runned_result.Success exp2 ->
       let _ = Ast_core.Misc.assert_value_eq (exp1, exp2) in
       Lwt.return exp1
-    | _ -> raise.error test_not_expected_to_fail
-  else
-    let%bind res = run_typed_program_with_imperative_input_twice_single ~raise ?options:opt_options ~config_options:options program entry_point input1 input2 in
+    | _ -> raise.error test_not_expected_to_fail)
+  else (
+    let%bind res =
+      run_typed_program_with_imperative_input_twice_single
+        ~raise
+        ?options:opt_options
+        ~config_options:options
+        program
+        entry_point
+        input1
+        input2
+    in
     match res with
     | Runned_result.Success exp -> Lwt.return exp
-    | _ -> raise.error test_not_expected_to_fail
+    | _ -> raise.error test_not_expected_to_fail)
 
 
 let expect ~raise ?options program entry_point input expecter =
   let result =
     Lwt_main.run
     @@ Trace.trace ~raise (test_run_tracer entry_point)
-    @@ run_typed_program_with_imperative_input ?opt_options:options program entry_point input
+    @@ run_typed_program_with_imperative_input
+         ?opt_options:options
+         program
+         entry_point
+         input
   in
   expecter result
 
 
-let expect_twice ~raise ?options ?(with_lltz = true) program entry_point input1 input2 expecter =
+let expect_twice
+    ~raise
+    ?options
+    ?(with_lltz = true)
+    program
+    entry_point
+    input1
+    input2
+    expecter
+  =
   let result =
     Lwt_main.run
     @@ Trace.trace ~raise (test_run_tracer entry_point)
@@ -473,7 +544,12 @@ let expect_fail ~raise ?options program entry_point input =
   Trace.Assert.assert_fail ~raise test_expected_to_fail
   @@ fun ~raise ->
   Lwt_main.run
-  @@ run_typed_program_with_imperative_input ~raise ?opt_options:options program entry_point input
+  @@ run_typed_program_with_imperative_input
+       ~raise
+       ?opt_options:options
+       program
+       entry_point
+       input
 
 
 let expect_fail_twice ~raise ?options program entry_point input1 input2 =
@@ -551,7 +627,16 @@ let expect_eq ~raise ?options program entry_point input expected =
   expect ~raise ?options program entry_point input expecter
 
 
-let expect_eq_twice ~raise ?options ?(with_lltz = true) program entry_point input1 input2 expected =
+let expect_eq_twice
+    ~raise
+    ?options
+    ?(with_lltz = true)
+    program
+    entry_point
+    input1
+    input2
+    expected
+  =
   let expected = expression_to_core ~raise expected in
   let expecter result =
     Trace.trace_option ~raise (test_expect_tracer expected result)
@@ -567,7 +652,14 @@ let expect_eq_core ~raise ?options program entry_point input expected =
   in
   expect ~raise ?options program entry_point input expecter
 
-let expect_evaluate ?(options = options) ~raise (program : Ast_typed.program) entry_point expecter =
+
+let expect_evaluate
+    ?(options = options)
+    ~raise
+    (program : Ast_typed.program)
+    entry_point
+    expecter
+  =
   let open Lwt.Let_syntax in
   Trace.trace ~raise (test_run_tracer entry_point)
   @@ fun ~raise ->
@@ -616,6 +708,7 @@ let expect_eq_evaluate ~raise (program : Ast_typed.program) entry_point expected
   let _ = expect_evaluate ~raise ~options program entry_point expecter in
   expect_evaluate ~raise ~options:options_with_lltz program entry_point expecter
 
+
 let expect_eq_n_trace_aux_twice
     ~raise
     ?options
@@ -629,7 +722,14 @@ let expect_eq_n_trace_aux_twice
     let input1, input2 = make_input n in
     let expected = make_expected n in
     Trace.trace ~raise (test_expect_n_tracer n)
-    @@ expect_eq_twice ?options ~with_lltz:false program entry_point input1 input2 expected
+    @@ expect_eq_twice
+         ?options
+         ~with_lltz:false
+         program
+         entry_point
+         input1
+         input2
+         expected
   in
   let _ = List.map ~f:aux lst in
   ()
@@ -706,20 +806,19 @@ let compile_main ?(options = options) ~raise f () =
   in
   let expanded = Ligo_compile.Of_aggregated.compile_expression ~raise agg in
   let mini_c = Ligo_compile.Of_expanded.compile_expression ~raise expanded in
-  Lwt_main.run (
-    let%bind michelson_prg =
-      Ligo_compile.Of_mini_c.compile_contract ~raise ~options mini_c
-    in
-    let%bind _contract =
-      (* Fails if the given entry point is not a valid contract *)
-      Ligo_compile.Of_michelson.build_contract ~raise michelson_prg []
-    in
-    let%bind michelson_prg_lltz =
-      Ligo_compile.Of_mini_c.compile_contract ~raise ~options:options_with_lltz mini_c
-    in
-    let%map _contract_lltz =
-      (* Fails if the given entry point is not a valid contract *)
-      Ligo_compile.Of_michelson.build_contract ~raise michelson_prg_lltz []
-    in
-    ()
-  )
+  Lwt_main.run
+    (let%bind michelson_prg =
+       Ligo_compile.Of_mini_c.compile_contract ~raise ~options mini_c
+     in
+     let%bind _contract =
+       (* Fails if the given entry point is not a valid contract *)
+       Ligo_compile.Of_michelson.build_contract ~raise michelson_prg []
+     in
+     let%bind michelson_prg_lltz =
+       Ligo_compile.Of_mini_c.compile_contract ~raise ~options:options_with_lltz mini_c
+     in
+     let%map _contract_lltz =
+       (* Fails if the given entry point is not a valid contract *)
+       Ligo_compile.Of_michelson.build_contract ~raise michelson_prg_lltz []
+     in
+     ())


### PR DESCRIPTION
## Context

Currently Ligo is not running the formatter on CI, such that small issues can be merged.

## Guideline

Running the following should fix all the formatting issues in the project.

```shell
nix fmt
```

This sometimes fails due to having a `result` folder at the root of the project, but that folder can be removed.

## Changes

This does both the adding the formatter and running it on everything.