### PR TITLE
Alan@lltz codegen/last vars tests

### DIFF
--- a/lib/ligo_lltz_codgen/ligo_lltz_codegen.ml
+++ b/lib/ligo_lltz_codgen/ligo_lltz_codegen.ml
@@ -2,7 +2,10 @@ open Core
 open Grace
 open Ligo_prim
 module I = Mini_c
-module O = Lltz_ir
+module O = struct
+  include Lltz_ir
+  module Dsl = Lltz_ir.Ast_builder.Default
+end
 module Ligo_string = Simple_utils.Ligo_string
 module Location = Simple_utils.Location
 module Lltz_codegen = Lltz_codegen
@@ -64,7 +67,7 @@ let rec compile_type_expression (type_ : I.type_expression) : O.Type.t =
   | T_base TB_bls12_381_fr -> return Bls12_381_fr
   | T_base TB_never -> return Never
   | T_base TB_tx_rollup_l2_address -> return Tx_rollup_l2_address
-  | T_base (TB_type_int _) -> return Int
+  | T_base (TB_type_int memo) -> return @@ Sapling_state { memo = (Z.to_int memo) }
   | T_base TB_chest -> return Chest
   | T_base TB_chest_key -> return Chest_key
   (* dead baker account support *)
@@ -161,27 +164,27 @@ let compile_constant (const : Constant.constant') (args: O.Expr.t list) (return_
   | C_LSR -> mk_prim Lsr
   | C_EQ -> (
     match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Eq
+    | a::b::tl -> mk_prim ~args:((O.Dsl.compare ~range a b)::tl) Eq
     | _ -> assert false)
   | C_NEQ -> (
     match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Neq
+    | a::b::tl -> mk_prim ~args:((O.Dsl.compare ~range a b)::tl) Neq
     | _ -> assert false)
   | C_LT -> (
     match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Lt
+    | a::b::tl -> mk_prim ~args:((O.Dsl.compare ~range a b)::tl) Lt
     | _ -> assert false)
   | C_GT -> (
     match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Gt
+    | a::b::tl -> mk_prim ~args:((O.Dsl.compare ~range a b)::tl) Gt
     | _ -> assert false)
   | C_LE -> (
     match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Le
+    | a::b::tl -> mk_prim ~args:((O.Dsl.compare ~range a b)::tl) Le
     | _ -> assert false)
   | C_GE -> (
     match args with
-    | a::b::tl -> mk_prim ~args:((O.Dsl.compare_ ~range a b)::tl) Ge
+    | a::b::tl -> mk_prim ~args:((O.Dsl.compare ~range a b)::tl) Ge
     | _ -> assert false)
   | C_CONCAT -> mk_prim Concat2
   | C_CONCATS -> mk_prim Concat1
@@ -190,9 +193,9 @@ let compile_constant (const : Constant.constant') (args: O.Expr.t list) (return_
   | C_SLICE -> (
     match args with
     | offset::length::seq::tl -> (
-      O.Dsl.if_none (O.Dsl.slice ~range offset ~length ~seq)
-        ~some:(let var_name = O.Dsl.gen_name () in
-          O.Dsl.annon_function var_name seq.type_ ~body:(O.Dsl.variable (Var var_name) seq.type_))
+      O.Dsl.if_none ~range (O.Dsl.slice ~range offset ~length ~seq)
+        ~some:(let var_name = O.Dsl.gen_name in
+          O.Dsl.annon_function var_name seq.type_ ~body:(O.Dsl.variable ~range (Var var_name) seq.type_))
         ~none:(O.Dsl.failwith ~range (O.Dsl.string ~range "Slice out of bounds"))
       ).desc
     | _ -> assert false)
@@ -268,10 +271,10 @@ let compile_constant (const : Constant.constant') (args: O.Expr.t list) (return_
   | C_MAP_FIND -> (
     match args with
     | key::coll::tl -> (
-      O.Dsl.if_none (O.Dsl.get ~range key coll)
-        ~some:(let var_name = O.Dsl.gen_name () in
+      O.Dsl.if_none ~range (O.Dsl.get ~range key coll)
+        ~some:(let var_name = O.Dsl.gen_name in
           (match coll.type_ with
-          | { desc = Map (key_ty, value_ty); _ } -> O.Dsl.annon_function var_name value_ty ~body:(O.Dsl.variable (Var var_name) value_ty)
+          | { desc = Map (key_ty, value_ty); _ } -> O.Dsl.annon_function var_name value_ty ~body:(O.Dsl.variable ~range (Var var_name) value_ty)
           | _ -> assert false)
           )
         ~none:(O.Dsl.failwith ~range (O.Dsl.string ~range "Key not found"))
@@ -365,8 +368,16 @@ let compile_constant (const : Constant.constant') (args: O.Expr.t list) (return_
     (* only interpreter *)
     assert false
   | C_GLOBAL_CONSTANT ->
-    (* TODO: removed in ?? *) 
-    assert false 
+    (match args with
+    | hash::args -> (
+      match hash with
+      | { desc = Const (String s); _ } -> (
+        match return_ty with
+        | { desc = O.Type.Function (param_ty, return_ty); _ } -> (
+          O.Dsl.global_constant ~range s args return_ty).desc
+        | _ -> assert false)
+      | _ -> assert false)
+    | _ -> assert false)
   | C_POLYMORPHIC_ADD ->
     (* removed in checking *)
     assert false
@@ -404,11 +415,11 @@ let compile_micheline_seq nodes =
   in
   Micheline.Seq (range, nodes)
 
-let rec compile_expression (expr : I.expression) : O.Expr.t =
+let rec compile_expression  (expr : I.expression) : O.Expr.t =
   let return_ty = compile_type_expression expr.type_expression in
   let range = compile_location expr.location in
   let return (desc : O.Expr.desc) : O.Expr.t =
-    { desc; range = range; type_ = return_ty }
+    { desc; range = range; type_ = return_ty; annotations = O.Annotations.empty }
   in
   match expr.content with
   | E_literal lit -> return @@ Const (compile_literal lit)
@@ -426,93 +437,94 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
     | _ -> assert false) in
     return @@ Lambda_rec { mu_var = (rec_var, return_ty); lambda ={lam_var = (var, var_ty); body} }
   | E_constant { cons_name; arguments } ->
-    let args = List.map arguments ~f:compile_expression in
+    let args = List.map arguments ~f:(compile_expression ) in
     return @@ (compile_constant cons_name args return_ty range)
   | E_application (abs, arg) ->
-    let abs = compile_expression abs in
-    let arg = compile_expression arg in
+    let abs = compile_expression  abs in
+    let arg = compile_expression  arg in
     return @@ App { abs; arg }
-  | E_variable var -> return @@ (Variable (compile_var var))
+  | E_variable var -> 
+    return @@ (Variable (compile_var var))
   | E_let_in (rhs, _inline, (binder, in_)) ->
     let (let_var, _) = compile_binder binder in
-    let rhs = compile_expression rhs in
-    let in_ = compile_expression in_ in
+    let rhs = compile_expression  rhs in
+    let in_ = compile_expression  in_ in
     return @@ Let_in { let_var; rhs; in_ }
   | E_let_mut_in (rhs, (binder, in_)) ->
     let let_var, _ = compile_mut_binder binder in
-    let rhs = compile_expression rhs in
-    let in_ = compile_expression in_ in
+    let rhs = compile_expression  rhs in
+    let in_ = compile_expression  in_ in
     return @@ Let_mut_in { let_var; rhs; in_ }
   | E_deref var -> return @@ Deref (compile_mut_var var)
   | E_assign (var, value) ->
     let var = compile_mut_var var in
-    let value = compile_expression value in
+    let value = compile_expression  value in
     return @@ Assign (var, value)
   | E_if_bool (condition, if_true, if_false) ->
-    let condition = compile_expression condition in
-    let if_true = compile_expression if_true in
-    let if_false = compile_expression if_false in
+    let condition = compile_expression  condition in
+    let if_true = compile_expression  if_true in
+    let if_false = compile_expression  if_false in
     return @@ If_bool { condition; if_true; if_false }
   | E_if_cons (subject, if_nil, ((hd_binder, tl_binder), if_cons)) -> 
-    let subject = compile_expression subject in
-    let if_nil = compile_expression if_nil in
+    let subject = compile_expression  subject in
+    let if_nil = compile_expression  if_nil in
     let hd_binder = compile_binder hd_binder in
     let tl_binder = compile_binder tl_binder in
-    let if_cons = compile_expression if_cons in
+    let if_cons = compile_expression  if_cons in
     return @@ If_cons { subject; if_empty = if_nil; if_nonempty = {lam_var1 = hd_binder; lam_var2 = tl_binder; body = if_cons} }
   | E_if_none (subject, if_none, (binder, if_some)) ->
-    let subject = compile_expression subject in
-    let if_none = compile_expression if_none in
+    let subject = compile_expression  subject in
+    let if_none = compile_expression  if_none in
     let binder = compile_binder binder in
-    let if_some = compile_expression if_some in
+    let if_some = compile_expression  if_some in
     return @@ If_none { subject; if_none; if_some = {lam_var = binder; body = if_some} }
   | E_if_left (subject, (left_binder, if_left), (right_binder, if_right)) ->
-    let subject = compile_expression subject in
+    let subject = compile_expression  subject in
     let left_binder = compile_binder left_binder in
-    let if_left = compile_expression if_left in
+    let if_left = compile_expression  if_left in
     let right_binder = compile_binder right_binder in
-    let if_right = compile_expression if_right in
+    let if_right = compile_expression  if_right in
     return
     @@ If_left
          { subject; if_left = {lam_var = left_binder; body = if_left}; if_right = {lam_var = right_binder; body=if_right} }
   | E_while (cond, body) ->
-    let cond = compile_expression cond in
-    let body = compile_expression body in
+    let cond = compile_expression  cond in
+    let body = compile_expression  body in
     return @@ While { cond; body }
   | E_for (start, stop, step, (index, body)) ->
-    let start = compile_expression start in
-    let stop = compile_expression stop in
-    let step = compile_expression step in
+    let start = compile_expression  start in
+    let stop = compile_expression  stop in
+    let step = compile_expression  step in
     let index, index_ty = compile_mut_binder index in
-    let body = compile_expression body in
+    let body = compile_expression  body in
     return @@ For { init = start; 
       cond = O.Dsl.le ~range (O.Dsl.deref ~range index index_ty) (stop); 
-      update = O.Dsl.assign index (O.Dsl.add ~range (O.Dsl.deref ~range index index_ty) step); 
+      update = O.Dsl.assign ~range index (O.Dsl.add ~range (O.Dsl.deref ~range index index_ty) step); 
       index; body }
   | E_for_each (collection, _type, (binders, body)) ->
-    let collection = compile_expression collection in
-    let var, body = compile_binders binders ~in_:(compile_expression body) in
+    let collection = compile_expression  collection in
+    let var, body = compile_binders binders ~in_:(compile_expression  body) in
     return @@ For_each { collection; body = {lam_var = var; body} }
   | E_tuple elts ->
-    let elts = List.map elts ~f:compile_expression in
+    let elts = List.map elts ~f:(compile_expression ) in
     let row = O.Row.(Node (List.map elts ~f:(fun elt -> Leaf (None, elt)))) in
     return @@ Tuple row
   | E_proj (tuple, index, _tuple_size) ->
-    let tuple = compile_expression tuple in
+    let tuple = compile_expression  tuple in
     return @@ Proj (tuple, O.Row.Path.Here [ index ])
   | E_update (tuple, index, update, _tuple_size) ->
-    let tuple = compile_expression tuple in
-    let update = compile_expression update in
+    let tuple = compile_expression  tuple in
+    let update = compile_expression  update in
     return @@ Update { tuple; component = O.Row.Path.Here [ index ]; update }
   | E_let_tuple (rhs, (binders, in_)) ->
     let components = List.map (List.map binders ~f:compile_binder) ~f:fst in
-    let rhs = compile_expression rhs in
-    let in_ = compile_expression in_ in
+    let rhs = compile_expression  rhs in
+    let in_ = compile_expression  in_ in
     return @@ Let_tuple_in { components; rhs; in_ }
   | E_iterator (iter_const, (binder, body), collection) ->
-    let collection = compile_expression collection in
+    let collection = compile_expression  collection in
     let binder = compile_binder binder in
-    let body = compile_expression body in
+    let body = compile_expression  body in
     (match iter_const with
     | Constant.C_ITER -> return @@ For_each { collection; body = {lam_var = binder; body} }
     | Constant.C_MAP -> return @@ Map { collection; map = {lam_var = binder; body} }
@@ -520,16 +532,16 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
       return @@ While_left { cond = collection; body = {lam_var = binder; body} }
     | _ -> assert false)
   | E_fold ((binder, body), collection, init) ->
-    let collection = compile_expression collection in
-    let init = compile_expression init in
+    let collection = compile_expression  collection in
+    let init = compile_expression  init in
     let binder = compile_binder binder in
-    let body = compile_expression body in
+    let body = compile_expression  body in
     return @@ Fold_left { collection; init; fold = {lam_var=binder; body} }
   | E_fold_right ((binder, body), (collection, _elt_type), init) ->
-    let collection = compile_expression collection in
-    let init = compile_expression init in
+    let collection = compile_expression  collection in
+    let init = compile_expression  init in
     let binder = compile_binder binder in
-    let body = compile_expression body in
+    let body = compile_expression  body in
     return @@ Fold_right { collection; init; fold = {lam_var=binder; body} }
   | I.E_raw_michelson nodes ->
     let micheline = compile_micheline_seq nodes in
@@ -539,7 +551,7 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
       return
       @@ Lambda
            { lam_var = (var, var_ty)
-           ; body = {desc = Raw_michelson { michelson = micheline; args = [ O.Dsl.variable ~range var var_ty ]}; range = range; type_= body_ty}
+           ; body = {desc = Raw_michelson { michelson = micheline; args = [ O.Dsl.variable ~range var var_ty ]}; range = range; type_= body_ty; annotations = O.Annotations.empty}
            }
     | _ -> assert false)
   | E_inline_michelson (code, args') ->
@@ -547,7 +559,9 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
     return @@ Raw_michelson { michelson = micheline; args }
 
   | I.E_global_constant (hash, args) ->
-    assert false
+    let args = List.map args ~f:(compile_expression ) in
+    return @@ Global_constant { hash; args }
+
     (*TODO: let args = List.map args ~f:compile_expression in
     return @@ Global_constant { hash; args }
 
@@ -565,10 +579,10 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
     let parameter = compile_type_expression parameter_type in
     let storage = compile_type_expression storage_type in
     let binder = compile_binder binder in
-    let code = compile_expression code in
-    let delegate = compile_expression delegate in
-    let initial_balance = compile_expression initial_balance in
-    let initial_storage = compile_expression initial_storage in
+    let code = compile_expression  code in
+    let delegate = compile_expression  delegate in
+    let initial_balance = compile_expression  initial_balance in
+    let initial_storage = compile_expression  initial_storage in
     return
     @@ Create_contract
          { 
@@ -580,22 +594,22 @@ let rec compile_expression (expr : I.expression) : O.Expr.t =
          }
   | E_create_contract _ -> assert false
 
-and compile_contract (binder:Value_var.t) (input_ty: I.type_expression) (body:I.expression) =
+and compile_contract  (binder:Value_var.t) (input_ty: I.type_expression) (body:I.expression) =
   let binder = compile_var binder in
   let input_ty = compile_type_expression input_ty in
-  let body = compile_expression body in
+  let body = compile_expression  body in
   binder, input_ty, body
 
 and compile_function ({ binder; body } : I.anon_function) =
   let ret_ty = compile_type_expression body.type_expression in
-  let body = compile_expression body in
+  let body = compile_expression  body in
   let lam_var = compile_var binder in
   lam_var, ret_ty, body
 
 and compile_tuple_index (index : int) : O.Row.Path.t = O.Row.Path.Here [ index ]
 
 and compile_binders binders ~(in_ : O.Expr.t) : (O.Expr.var * O.Type.t) * O.Expr.t =
-  let create_expr (desc : O.Expr.desc) : O.Expr.t = { desc = desc; range = in_.range; type_ = in_.type_  } in
+  let create_expr (desc : O.Expr.desc) : O.Expr.t = { desc = desc; range = in_.range; type_ = in_.type_; annotations = O.Annotations.empty  } in
   match binders with
   | [] -> assert false
   | [ binder ] -> compile_binder binder, in_
@@ -609,7 +623,7 @@ and compile_binders binders ~(in_ : O.Expr.t) : (O.Expr.var * O.Type.t) * O.Expr
 and compile_inline_michelson (code, args') =
   let args_compiled = List.map args' ~f:(
       fun e -> (
-        compile_expression e
+        compile_expression  e
     )) in
     let args_ty = List.map args' ~f:(
       fun e -> (
@@ -624,6 +638,20 @@ and compile_inline_michelson (code, args') =
     let replace m =
       let open Tezos_micheline.Micheline in
       match m with
+      | Prim (_, "SAPLING_EMPTY_STATE", [Prim (_, s, [], [id])], [])
+        when String.equal "typeopt" s && String.is_prefix ~prefix:"$" id ->
+        let id = String.chop_prefix_exn ~prefix:"$" id in
+        let id = Int.of_string id in
+        used := id :: !used;
+        (match List.nth args_ty id with
+        | Some (prim) ->
+          (match (Lltz_codegen.convert_type prim) with
+          | (Prim (_, Michelson.Ast.Prim.T Michelson.Ast.Prim.Type.Option, [ Prim (_, _, [Int(_,z)], _) ], _))  
+          -> 
+            let instruction = Michelson.Ast.Instruction.sapling_empty_state (Int.of_string (Z.to_string z)) in
+            Tezos_micheline.Micheline.map_node (fun _ -> ()) (fun prim -> Michelson.Ast.Prim.to_string prim) (instruction)
+          | _ -> raise_s [%message "could not resolve (SAPLING_EMPTY_STATE $)" (id : int)])
+        | _ -> assert false)
       | Prim (_, s, [], [ id ])
         when String.equal "typeopt" s && String.is_prefix ~prefix:"$" id ->
         let id = String.chop_prefix_exn ~prefix:"$" id in
@@ -707,5 +735,5 @@ and compile_inline_michelson (code, args') =
     in
     let code = (List.map ~f:(wipe_locations (dummy_loc)) code) in
     let micheline = compile_micheline_seq code in
-    let args = List.map args' ~f:compile_expression in
+    let args = List.map args' ~f:(compile_expression ) in
     micheline, args

--- a/src/main/compile/of_mini_c.ml
+++ b/src/main/compile/of_mini_c.ml
@@ -55,8 +55,106 @@ let compile_type e =
   let expr_ty = Scoping.translate_type e in
   dummy_locations (To_micheline.translate_type expr_ty)
 
-
 let compile_contract ~raise
+: options:Compiler_options.t -> expression -> Stacking.compiled_expression Lwt.t
+=
+  fun ~options e_contract ->
+  let open Lwt.Let_syntax in
+  let input_ty, contract = optimize_for_contract ~raise options e_contract in
+
+  (* Compile with IR *)
+  let%bind expr_ir =
+    let e_optimised = trace ~raise self_mini_c_tracer @@ Self_mini_c.all_expression options contract.body in
+    let expr =
+      let (Var lltz_var, lltz_ty, lltz_body) =
+        Ligo_lltz_codegen.compile_contract contract.binder input_ty e_optimised
+      in
+      Lltz_codegen.compile_contract_to_micheline lltz_var lltz_ty lltz_body []
+    in
+    let%map expr = Lwt.return (Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr) in
+    Self_michelson.optimize
+      ~experimental_disable_optimizations_for_debugging:
+        options.backend.experimental_disable_optimizations_for_debugging
+      ~has_comment:(has_comment options)
+      expr
+  in
+
+  (* Compile with IR *)
+  let%bind expr_ir_no_opt =
+    let e_optimised = trace ~raise self_mini_c_tracer @@ Self_mini_c.all_expression options contract.body in
+    let expr =
+      let (Var lltz_var, lltz_ty, lltz_body) =
+        Ligo_lltz_codegen.compile_contract contract.binder input_ty e_optimised
+      in
+      Lltz_codegen.compile_contract_to_micheline lltz_var lltz_ty lltz_body []
+    in
+    let%map expr = Lwt.return (Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr) in
+    (*Printf.printf "expr_ir_no_opt preopt:";
+    let open Micheline_printer in
+      expr |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;*)
+      expr
+  in
+
+  (* Compile without IR *)
+  let%bind expr_no_ir =
+    let de_bruijn =
+      trace ~raise scoping_tracer @@ Scoping.translate_closed_function contract input_ty
+    in
+    let%map expr = Stacking.Program.compile_function_body de_bruijn in
+    (*Printf.printf "expr_no_ir preopt:";
+    let open Micheline_printer in
+      expr |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;*)
+    Self_michelson.optimize
+      ~experimental_disable_optimizations_for_debugging:
+        options.backend.experimental_disable_optimizations_for_debugging
+      ~has_comment:(has_comment options)
+      expr
+  in
+
+  (* Measure code sizes *)
+  let%bind size_ir = Of_michelson.measure ~raise expr_ir in
+  let%bind size_no_ir = Of_michelson.measure ~raise expr_no_ir in
+  let%bind size_ir_no_opt = Of_michelson.measure ~raise expr_ir_no_opt in
+
+  let _ = (if size_ir_no_opt > size_no_ir then 
+    (Printf.printf "SIZE (IR_NO_OPT, NO_IR): (%d, %d)\n" size_ir_no_opt size_no_ir;
+    let open Micheline_printer in
+      expr_ir_no_opt |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;
+    let open Micheline_printer in
+      expr_no_ir |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;
+    47)
+  else 9) in
+
+  let _ = (if size_ir_no_opt > size_ir then 
+    (Printf.printf "SIZE (IR_NO_OPT, IR): (%d, %d)\n" size_ir_no_opt size_ir;
+    let open Micheline_printer in
+      expr_ir |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;
+    let open Micheline_printer in
+      expr_ir_no_opt |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;
+    47)
+  else 9) in
+    
+
+  (* Output pair of sizes to a file *)
+    (*let output_file = "code_sizes.txt" in
+    let%bind () =
+      Lwt_io.with_file
+        ~mode:Lwt_io.Output
+        ~flags:[Core_unix.O_WRONLY; Core_unix.O_CREAT; Core_unix.O_APPEND]
+        output_file
+        (fun oc ->
+          let content = Printf.sprintf "contract (%d, %d)\n" size_ir size_no_ir in
+          Lwt_io.write oc content
+        )
+    in*)
+
+  (* Return the value as before *)
+  let expr_to_return = if (*options.backend.lltz_ir*) true then expr_ir_no_opt else expr_no_ir in (*ir no opt todo*)
+  let expr_ty = compile_type e_contract.type_expression in
+  let expr_ty = dummy_locations expr_ty in
+  Lwt.return ({ expr_ty; expr = expr_to_return } : Stacking.Program.compiled_expression)
+
+(*let compile_contract ~raise
     : options:Compiler_options.t -> expression -> Stacking.compiled_expression Lwt.t
   =
  fun ~options e_contract ->
@@ -72,27 +170,12 @@ let compile_contract ~raise
           expr
   in
   let%map expr =
-    if options.backend.lltz_ir then
-      let e_simplified = trace ~raise self_mini_c_tracer @@ Self_mini_c.all_expression options contract.body in
-
-      let expr_unoptimised = 
-        let (Var lltz_var, lltz_ty, lltz_body) = Ligo_lltz_codegen.compile_contract contract.binder input_ty e_simplified in
-        Lltz_codegen.compile_contract_to_micheline ~optimize:false lltz_var lltz_ty lltz_body [] in
-      let expr_unoptimised = Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr_unoptimised in 
-      
-      let expr_optimised = 
-        let (Var lltz_var, lltz_ty, lltz_body) = Ligo_lltz_codegen.compile_contract contract.binder input_ty e_simplified in
-        Lltz_codegen.compile_contract_to_micheline ~optimize:true lltz_var lltz_ty lltz_body [] in
-      let expr_optimised = Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr_optimised in 
-
-      let%bind size_optimised = Of_michelson.measure ~raise (expr_optimised) in
-      let%bind size_unoptimised = Of_michelson.measure ~raise expr_unoptimised in
-
-      (* Assert that size with lltz is smaller than without *)
-      if size_optimised > size_unoptimised then
-        assert false
-      else
-        Lwt.return expr_optimised
+    if true then
+      let e_optimised = trace ~raise self_mini_c_tracer @@ Self_mini_c.all_expression options contract.body in
+      let expr = 
+        let (Var lltz_var, lltz_ty, lltz_body) = Ligo_lltz_codegen.compile_contract contract.binder input_ty e_optimised in
+        Lltz_codegen.compile_contract_to_micheline lltz_var lltz_ty lltz_body [] in
+      Lwt.return (Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr)
     else
       let de_bruijn =
         trace ~raise scoping_tracer @@ Scoping.translate_closed_function contract input_ty
@@ -102,9 +185,18 @@ let compile_contract ~raise
 
       Lwt.return optimised_expr
   in
+    let expr =
+      Self_michelson.optimize
+        ~experimental_disable_optimizations_for_debugging:
+          options.backend.experimental_disable_optimizations_for_debugging
+        ~has_comment:(has_comment options)
+        expr
+    in
+    (*let open Micheline_printer in
+      expr |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;*)
     let expr_ty = compile_type e_contract.type_expression in
     let expr_ty = dummy_locations expr_ty in
-    ({ expr_ty; expr } : Stacking.Program.compiled_expression)
+    ({ expr_ty; expr } : Stacking.Program.compiled_expression)*)
 
 
 let compile_view ~raise
@@ -145,7 +237,7 @@ let compile_view ~raise
   ({ expr_ty; expr } : Stacking.Program.compiled_expression)
 
 
-let compile_expression ~raise
+(*let compile_expression ~raise
     : options:Compiler_options.t -> expression -> compiled_expression Lwt.t
   =
     fun ~options e ->
@@ -162,32 +254,95 @@ let compile_expression ~raise
       in
 
       let%map expr = 
-        if options.backend.lltz_ir then
-          let expr_lltz_opt = Lltz_codegen.compile_to_micheline ~optimize:true (Ligo_lltz_codegen.compile_expression e) [] in
-          let expr_optimised =
-            Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr_lltz_opt
-          in
-
-          let expr_lltz_unopt = Lltz_codegen.compile_to_micheline ~optimize:false (Ligo_lltz_codegen.compile_expression e) [] in
-          let expr_unoptimised =
-            Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr_lltz_unopt
-          in
-
-          let%bind size_optimised = Of_michelson.measure ~raise expr_optimised in
-          let%bind size_unoptimised = Of_michelson.measure ~raise expr_unoptimised in
-
-          (* Assert that size with lltz michelson optimisations is smaller than without *)
-          if size_optimised > size_unoptimised then
-            assert false
-          else
-            Lwt.return expr_optimised
+        if false then
+          let expr = Lltz_codegen.compile_to_micheline (Ligo_lltz_codegen.compile_expression e) [] in
+          Lwt.return (optimize (Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr))
         else
           let expr = trace ~raise scoping_tracer @@ Scoping.translate_expression e [] in
           let%bind expr = Stacking.Program.compile_expr [] expr in
           Lwt.return (optimize expr)
       in
+      (*let open Micheline_printer in
+      expr |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;*)
         let expr_ty = compile_type e.type_expression in
-        (({ expr_ty; expr } : Program.compiled_expression))
+        (({ expr_ty; expr } : Program.compiled_expression))*)
+
+let compile_expression ~raise
+: options:Compiler_options.t -> expression -> compiled_expression Lwt.t
+=
+fun ~options e ->
+  let e = trace ~raise self_mini_c_tracer @@ Self_mini_c.all_expression options e in
+  let open Lwt.Let_syntax in
+
+  (* Compile with IR *)
+  let%bind expr_ir =
+    let expr = Lltz_codegen.compile_to_micheline (Ligo_lltz_codegen.compile_expression e) [] in
+    let%map expr = Lwt.return (Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr) in
+    Self_michelson.optimize
+      ~experimental_disable_optimizations_for_debugging:
+        options.backend.experimental_disable_optimizations_for_debugging
+      ~has_comment:(has_comment options)
+      expr
+  in
+
+  (* Compile with IR *)
+  let%bind expr_ir_no_opt =
+    let expr = Lltz_codegen.compile_to_micheline (Ligo_lltz_codegen.compile_expression e) [] in
+    let%map expr = Lwt.return (Micheline.map_node (fun _ -> dummy) (fun prim -> Michelson.Ast.Prim.to_string prim) expr) in
+    expr
+  in
+
+  (* Compile without IR *)
+  let%bind expr_no_ir =
+    let expr = trace ~raise scoping_tracer @@ Scoping.translate_expression e [] in
+    let%map expr = Stacking.Program.compile_expr [] expr in
+    Self_michelson.optimize
+      ~experimental_disable_optimizations_for_debugging:
+        options.backend.experimental_disable_optimizations_for_debugging
+      ~has_comment:(has_comment options)
+      expr
+  in
+
+  (* Measure code sizes *)
+  let%bind size_ir = Of_michelson.measure ~raise expr_ir in
+  let%bind size_no_ir = Of_michelson.measure ~raise expr_no_ir in
+  let%bind size_ir_no_opt = Of_michelson.measure ~raise expr_ir_no_opt in
+
+  let _ = (if size_ir_no_opt > size_no_ir then 
+    (Printf.printf "SIZE (IR_NO_OPT, NO_IR): (%d, %d)\n" size_ir_no_opt size_no_ir;
+    let open Micheline_printer in
+      expr_ir_no_opt |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;
+    let open Micheline_printer in
+      expr_no_ir |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;
+    47)
+  else 9) in
+
+  let _ = (if size_ir_no_opt > size_ir then 
+    (Printf.printf "SIZE (IR_NO_OPT, IR): (%d, %d)\n" size_ir_no_opt size_ir;
+    let open Micheline_printer in
+      expr_ir |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;
+    let open Micheline_printer in
+      expr_ir_no_opt |> Micheline.strip_locations |> printable (fun value -> value) |> print_expr Format.std_formatter;
+    47)
+  else 9) in
+
+  (* Output pair of sizes to a file *)
+  (*let output_file = "code_sizes.txt" in
+  let%bind () =
+    Lwt_io.with_file
+      ~mode:Lwt_io.Output
+      ~flags:[Core_unix.O_WRONLY; Core_unix.O_CREAT; Core_unix.O_APPEND]
+      output_file
+      (fun oc ->
+        let content = Printf.sprintf "(%d, %d)\n" size_ir size_no_ir in
+        Lwt_io.write oc content
+      )
+  in*)
+
+  (* Return the value as before *)
+  let expr_to_return = if (*options.backend.lltz_ir*) true then expr_ir_no_opt else expr_no_ir in
+  let expr_ty = compile_type e.type_expression in
+  Lwt.return ({ expr_ty; expr = expr_to_return } : Program.compiled_expression)
 
 let compile_expression_function ~raise
     : options:Compiler_options.t -> expression -> compiled_expression Lwt.t

--- a/src/main/compiler_options/raw_options.ml
+++ b/src/main/compiler_options/raw_options.ml
@@ -86,7 +86,7 @@ module Default_options = struct
   let constants = []
   let file_constants = None
   let function_body = false
-  let lltz_ir = false
+  let lltz_ir = true
   let preprocess_define = []
 end
 

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,7 @@
 (library
  (name test_dsl)
- (libraries core ligo.lltz_codegen fmt octez-libs.micheline)
- (modules test_nodes test_free_vars)
+ (libraries core ligo.lltz_codegen fmt octez-libs.micheline lltz.michelson)
+ (modules test_nodes test_free_vars test_all_vars test_used_vars test_last_vars)
  (inline_tests)
  (preprocess (pps ppx_jane))
  (flags (:standard -verbose -ccopt --verbose))

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,8 @@
+(library
+ (name test_dsl)
+ (libraries core ligo.lltz_codegen fmt octez-libs.micheline)
+ (modules test_nodes test_free_vars)
+ (inline_tests)
+ (preprocess (pps ppx_jane))
+ (flags (:standard -verbose -ccopt --verbose))
+)

--- a/test/test_all_vars.ml
+++ b/test/test_all_vars.ml
@@ -1,0 +1,499 @@
+open Core
+module Last_vars = Lltz_codegen.Last_vars
+module Ast_builder = Lltz_ir.Ast_builder
+open Lltz_ir.Ast_builder.With_dummy
+
+
+let print_vars expr =
+  let vars =Last_vars.collect_all_vars expr in
+  vars
+  |> Set.to_list
+  |> String.concat ~sep:", "
+  |> print_endline
+
+let v_x_nat = var "x"
+let v_y_nat = var "y"
+let mut_m_nat = mut_var "m"
+
+let%expect_test "vars simple overshadowing" =
+  let expr =
+    let_in (var "z") ~rhs:(int 5)
+      ~in_:
+        (let_in (var "z") ~rhs:(nat 10)
+          ~in_:(add (variable (var "z") nat_ty) (variable (var "z") nat_ty)))
+  in
+  print_vars expr;
+  [%expect {|
+    z
+  |}]
+
+let%expect_test "vars lambda overshadow outer" =
+  let expr =
+    let_in (var "a") ~rhs:(nat 99)
+      ~in_:
+        (lambda (var "a", nat_ty)
+          ~body:(
+            add
+              (variable (var "a") nat_ty)
+              (variable (var "a") nat_ty)
+          ))
+  in
+  print_vars expr;
+  [%expect {|
+    a
+  |}]
+
+let%expect_test "vars lambda_rec" =
+  let expr =
+    lambda_rec (var "fact") (var "n", nat_ty)
+      ~body:(
+        if_bool
+          (le (variable (var "n") nat_ty) (nat 1))
+          ~then_:(nat 1)
+          ~else_:(mul
+                    (variable (var "n") nat_ty)
+                    (app (variable (var "fact") (function_ty nat_ty nat_ty))
+                         (sub (variable (var "n") nat_ty) (nat 1)))))
+  in
+  print_vars expr;
+  [%expect {|
+    fact, n
+  |}]
+
+let%expect_test "vars lambda_rec + outer" =
+  let expr =
+    let_in (var "outer") ~rhs:(int 10)
+      ~in_:
+        (lambda_rec (var "f") (var "x", int_ty)
+          ~body:(
+            if_bool
+              (lt (variable (var "x") int_ty) (variable (var "outer") int_ty))
+              ~then_:(app (variable (var "f") (function_ty int_ty int_ty))
+                          (add (variable (var "x") int_ty) (int 1)))
+              ~else_:(variable (var "outer") int_ty)
+          ))
+  in
+  print_vars expr;
+  [%expect {|
+    f, outer, x
+  |}]
+
+let%expect_test "vars app overshadow in function" =
+  let lam_expr =
+    lambda (var "y", nat_ty)
+      ~body:(
+        let_in (var "y") ~rhs:(nat 99)
+          ~in_:(variable (var "y") nat_ty)
+      )
+  in
+  let expr = app lam_expr (variable (var "x") nat_ty) in
+  print_vars expr;
+  [%expect {|
+    x, y
+  |}]
+
+let%expect_test "vars app overshadow in argument" =
+  let f_expr =
+    lambda (var "t", int_ty)
+      ~body:(add (variable (var "t") int_ty) (int 1))
+  in
+  let overshadowed_arg =
+    let_in (var "t") ~rhs:(int 100)
+      ~in_:(variable (var "t") int_ty)
+  in
+  let expr = app f_expr overshadowed_arg in
+  print_vars expr;
+  [%expect {|
+    t
+  |}]
+
+let%expect_test "vars const int 42" =
+  let expr = int 42 in
+  print_vars expr;
+  [%expect {| |}]
+
+let%expect_test "vars const overshadow in let_in" =
+  let expr =
+    let_in (var "x") ~rhs:(int 5)
+      ~in_:(let_in (var "x") ~rhs:(int 10)
+              ~in_:(variable (var "x") int_ty))
+  in
+  print_vars expr;
+  [%expect {|
+    x
+  |}]
+
+let%expect_test "vars prim eq overshadow" =
+  let shadow_z =
+    let_in (var "z") ~rhs:(int 5)
+      ~in_:(variable (var "z") int_ty)
+  in
+  let expr = eq shadow_z (variable (var "z") int_ty) in
+  print_vars expr;
+  [%expect {|
+    z
+  |}]
+
+let%expect_test "vars prim add overshadow in both arguments" =
+  let lhs =
+    let_in (var "a") ~rhs:(nat 1)
+      ~in_:(variable (var "a") nat_ty)
+  in
+  let rhs =
+    let_in (var "a") ~rhs:(nat 2)
+      ~in_:(variable (var "a") nat_ty)
+  in
+  let expr = add lhs rhs in
+  print_vars expr;
+  [%expect {|
+    a
+  |}]
+
+let%expect_test "vars let_mut_in deref assign" =
+  let expr =
+    let_mut_in (mut_var "m") ~rhs:(nat 0)
+      ~in_:
+        (let_in (var "dummy") ~rhs:(
+          assign (mut_var "m")
+            (add (deref (mut_var "m") nat_ty) (variable (var "z") nat_ty))
+        )
+          ~in_:(deref (mut_var "m") nat_ty))
+  in
+  print_vars expr;
+  [%expect {|
+    dummy, m, z
+  |}]
+
+let%expect_test "vars deref alone free" =
+  let expr =
+    deref (mut_var "m") nat_ty
+  in
+  print_vars expr;
+  [%expect {|
+    m
+  |}]
+
+let%expect_test "vars deref overshadow" =
+  let expr =
+    let_mut_in (mut_var "m") ~rhs:(nat 10)
+      ~in_:(deref (mut_var "m") nat_ty)
+  in
+  print_vars expr;
+  [%expect {|
+    m
+  |}]
+
+let%expect_test "vars if_bool overshadow in condition" =
+  let cond_expr =
+    let_in (var "c") ~rhs:(int 5)
+      ~in_:(variable (var "c") int_ty)
+  in
+  let then_expr =
+    let_in (var "c") ~rhs:(int 10)
+      ~in_:(variable (var "c") int_ty)
+  in
+  let else_expr =
+    let_in (var "c") ~rhs:(int 20)
+      ~in_:(variable (var "c") int_ty)
+  in
+  let expr = if_bool cond_expr ~then_:then_expr ~else_:else_expr in
+  print_vars expr;
+  [%expect {|
+    c
+  |}]
+
+let%expect_test "vars if_bool referencing one free var in cond, different in then, else" =
+  let cond_expr = eq (variable (var "condX") int_ty) (int 1) in
+  let then_expr = add (variable (var "thY") int_ty) (int 2) in
+  let else_expr = sub (variable (var "elZ") int_ty) (int 3) in
+  let expr = if_bool cond_expr ~then_:then_expr ~else_:else_expr in
+  print_vars expr;
+  [%expect {|
+    condX, elZ, thY
+  |}]
+
+let%expect_test "vars if_none" =
+  let expr =
+    if_none (some (int 5))
+      ~none:(nat 999)
+      ~some:{
+        lam_var = (var "k", int_ty);
+        body = add (variable (var "k") int_ty) (variable (var "c") nat_ty)
+      }
+  in
+  print_vars expr;
+  [%expect {|
+    c, k
+  |}]
+
+let%expect_test "vars if_cons overshadow in nonempty" =
+  let expr =
+    if_cons (nil nat_ty)
+      ~empty:(int 0)
+      ~nonempty:{
+        lam_var1 = (var "hd", nat_ty);
+        lam_var2 = (var "hd", list_ty nat_ty);
+        body = add
+          (variable (var "hd") nat_ty)
+          (nat 1)
+      }
+  in
+  print_vars expr;
+  [%expect {|
+    hd
+  |}]
+
+let%expect_test "vars if_left overshadow in right" =
+  let left_expr = left (None, None, bool_ty) (bool false) in
+  let expr =
+    if_left left_expr
+      ~left:{
+        lam_var = (var "lf", bool_ty);
+        body = bool true
+      }
+      ~right:{
+        lam_var = (var "lf", bool_ty); 
+        body = variable (var "lf") bool_ty
+      }
+  in
+  print_vars expr;
+  [%expect {|
+    lf
+  |}]
+
+let%expect_test "vars while referencing multiple var" =
+  let expr =
+    while_ (eq (variable (var "x") nat_ty) (nat 0))
+      ~body:(
+        assign (mut_var "m")
+          (add (deref (mut_var "m") nat_ty) (variable (var "y") nat_ty))
+      )
+  in
+  print_vars expr;
+  [%expect {|
+    m, x, y
+  |}]
+
+let%expect_test "vars while_left overshadow var in body" =
+  let expr =
+    while_left (left (None,None,int_ty) (int 10)) ~body:{
+      lam_var = (var "lv", int_ty);
+      body =
+        let_in (var "lv") ~rhs:(int 999)
+          ~in_:(right (None,None,int_ty) (int 42))
+    }
+  in
+  print_vars expr;
+  [%expect{| lv |}]
+
+let%expect_test "vars while_left referencing outer var" =
+  let left_cond =
+    left (None,None,bool_ty) (variable (var "outerW") bool_ty)
+  in
+  let expr = while_left left_cond ~body:{
+      lam_var=(var "v", bool_ty);
+      body=let_in (var "v") ~rhs:(bool false)
+             ~in_:(right (None,None,bool_ty) (variable (var "v") bool_ty))
+    }
+  in
+  print_vars expr;
+  [%expect{| outerW, v |}]
+
+let%expect_test "vars for" =
+  let expr =
+    for_ (mut_var "i")
+      ~init:(nat 0)
+      ~cond:(lt (deref (mut_var "i") nat_ty) (nat 5))
+      ~update:(assign (mut_var "i") (add (deref (mut_var "i") nat_ty) (nat 1)))
+      ~body:(assign (mut_var "x") (deref (mut_var "i") nat_ty))
+  in
+  print_vars expr;
+  [%expect {|
+    i, x
+  |}]
+
+let%expect_test "vars for_each overshadow lam_var" =
+  let items = cons (int 1) (nil int_ty) in
+  let expr =
+    for_each items ~body:{
+      lam_var=(var "elem", int_ty);
+      body=let_in (var "elem") ~rhs:(int 999) ~in_:(variable (var "elem") int_ty)
+    }
+  in
+  print_vars expr;
+  [%expect {|
+    elem
+  |}]
+
+let%expect_test "vars map referencing outer var inside lam" =
+  let list_expr = cons (string "a") (nil string_ty) in
+  let expr =
+    let_in (var "outer") ~rhs:(string "S")
+      ~in_:
+        (map list_expr ~map:{
+          lam_var=(var "v",string_ty);
+          body=concat1 (variable (var "v") string_ty)
+                       (variable (var "outer") string_ty)
+        })
+  in
+  print_vars expr;
+  [%expect {|
+    outer, v
+  |}]
+
+let%expect_test "vars fold_left overshadow lam var" =
+  let list_expr = cons (nat 1) (cons (nat 2) (nil nat_ty)) in
+  let expr =
+    fold_left list_expr ~init:(nat 0)
+      ~fold:{
+        lam_var=(var "pairAcc", tuple_ty (mk_row [
+          Leaf(None, nat_ty); Leaf(None, nat_ty)
+        ]));
+        body=let_in (var "pairAcc") ~rhs:(nat 999)
+               ~in_:(nat 100)
+      }
+  in
+  print_vars expr;
+  [%expect {|
+    pairAcc
+  |}]
+
+let%expect_test "vars fold_right with outside ref" =
+  let lst = cons (int 1) (nil int_ty) in
+  let expr =
+    let_in (var "outer_f") ~rhs:(int 10)
+      ~in_:
+        (fold_right lst ~init:(int 0)
+          ~fold:{
+            lam_var = (var "ea", tuple_ty (mk_row [
+              Leaf(None,int_ty); Leaf(None,int_ty)
+            ]));
+            body = add
+              (car (variable (var "ea") (mk_tuple_ty [int_ty; int_ty])))
+              (add
+                 (cdr (variable (var "ea") (mk_tuple_ty [int_ty; int_ty])))
+                 (variable (var "outer_f") int_ty))
+          })
+  in
+  print_vars expr;
+  [%expect {|
+    ea, outer_f
+  |}]
+
+let%expect_test "vars tuple overshadow" =
+  let expr =
+    tuple (mk_row [
+      Leaf(None, variable (var "t") int_ty);
+      Leaf(None, let_in (var "t") ~rhs:(int 22) ~in_:(int 33))
+    ])
+  in
+  print_vars expr;
+  [%expect {|
+    t
+  |}]
+
+let%expect_test "vars proj referencing var" =
+  let triple = tuple (mk_row [
+    Leaf(None, variable (var "alpha") nat_ty);
+    Leaf(None, nat 2);
+    Leaf(None, nat 3)
+  ]) in
+  let expr = proj triple ~path:(Here [0]) in
+  print_vars expr;
+  [%expect {|
+    alpha
+  |}]
+
+let%expect_test "vars update overshadow" =
+  let original =
+    tuple (mk_row [
+      Leaf(None, int 1);
+      Leaf(None, int 2)
+    ])
+  in
+  let expr =
+    update_tuple original ~component:(Here [1])
+      ~update:(let_in (var "u") ~rhs:(int 10) ~in_:(variable (var "u") int_ty))
+  in
+  print_vars expr;
+  [%expect {|
+    u
+  |}]
+
+module MA = Michelson.Ast
+
+let push_int n = Tezos_micheline.Micheline.Prim (Ast_builder.Dummy_range.v, "PUSH", [Tezos_micheline.Micheline.Int(Ast_builder.Dummy_range.v, Z.of_int n)], [])
+
+let%expect_test "vars raw_michelson overshadow" =
+  let code_ast = Tezos_micheline.Micheline.Seq (Ast_builder.Dummy_range.v, [ push_int 42 ]) in
+  let expr =
+    raw_michelson code_ast
+      [ variable (var "x") int_ty
+      ; let_in (var "x") ~rhs:(int 10) ~in_:(int 20)
+      ]
+      int_ty
+  in
+  print_vars expr;
+  [%expect {|
+    x
+  |}]
+
+let%expect_test "vars create_contract overshadow binder_var" =
+  let param_storage_ty = mk_tuple_ty [nat_ty; nat_ty] in
+  let code_body =
+    let_tuple_in [var "p"; var "s"]
+      ~rhs:(variable (var "args") param_storage_ty)
+      ~in_:(add (variable (var "p") nat_ty) (variable (var "s") nat_ty))
+  in
+  let expr =
+    create_contract
+      ~storage:nat_ty
+      ~code:{ lam_var=(var "args", param_storage_ty); body=code_body }
+      ~delegate:(none key_hash_ty)
+      ~initial_balance:(mutez 1000)
+      ~initial_storage:(let_in (var "args") ~rhs:(nat 5) ~in_:(nat 6))
+  in
+  print_vars expr;
+  [%expect {|
+    args, p, s
+  |}]
+
+let%expect_test "vars global_constant overshadow args" =
+  let expr =
+    global_constant "hashQ"
+      [
+        let_in (var "x") ~rhs:(int 1) ~in_:(int 2);
+        variable (var "x") nat_ty
+      ]
+      (nat_ty)
+  in
+  print_vars expr;
+  [%expect {|
+    x
+  |}]
+
+  let%expect_test "vars combined scenario spot-check" =
+  let cond_expr =
+    left (None,None,bool_ty)
+      (gt (deref (mut_var "x") int_ty) (int 0))
+  in
+  let body_expr =
+    let_in (var "flg") ~rhs:(not (variable (var "flg") bool_ty))
+      ~in_:
+        (right (None,None,bool_ty) (app 
+          (variable (var "overshadowZ") (function_ty bool_ty bool_ty))
+          (eq (deref (mut_var "x") int_ty)
+              (let_in (var "overshadowZ") ~rhs:(int 5)
+                 ~in_:(variable (var "overshadowZ") int_ty)))
+          ))
+  in
+  let while_left_expr =
+    while_left cond_expr
+      ~body:{ lam_var=(var "flg", bool_ty); body=body_expr }
+  in
+  let expr =
+    let_mut_in (mut_var "x") ~rhs:(int 0)
+      ~in_:while_left_expr
+  in
+  print_vars expr;
+  [%expect{| flg, overshadowZ, x |}]

--- a/test/test_free_vars.ml
+++ b/test/test_free_vars.ml
@@ -1,0 +1,803 @@
+open Core
+open Lltz_ir.Ast_builder.With_dummy
+module FV = Lltz_ir.Free_vars
+module E = Lltz_ir.Ast_builder.With_dummy
+module LM = Lltz_codegen
+module Tezos_micheline = Tezos_micheline 
+module Ast_builder = Lltz_ir.Ast_builder
+
+let print_map_str_ty map =
+  Map.to_alist map
+  |> List.map ~f:(fun (k,v) ->
+       Printf.sprintf "%s : %s"
+         k
+         (Sexplib.Sexp.to_string_hum (Lltz_ir.Type.sexp_of_t v)))
+  |> String.concat ~sep:", "
+
+let print_free_vars expr =
+  let fv_map = FV.free_vars_with_types expr in
+  print_string (print_map_str_ty fv_map);
+  Format.print_newline ()
+
+let%expect_test "fv simple var + constant (no free vars)" =
+  let expr =
+    let_in (var "x") ~rhs:(nat 10)
+      ~in_:(add (variable (var "x") nat_ty) (int (-5)))
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv simple var + constant (one free var)" =
+  let expr =
+    add (variable (var "x") nat_ty) (int 5)
+  in
+  print_free_vars expr;
+  [%expect {|
+    x : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv overshadowed variable (no free var)" =
+  let expr =
+    let_in (var "z") ~rhs:(int 5)
+      ~in_:(let_in (var "z") ~rhs:(nat 99)
+              ~in_:(add (variable (var "z") nat_ty) (variable (var "z") nat_ty)))
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv overshadowed variable (one free var)" =
+  let expr =
+    let_in (var "z") ~rhs:(int 5)
+      ~in_:(
+        add (variable (var "z") nat_ty) (variable (var "unboundZ") int_ty)
+      )
+  in
+  print_free_vars expr;
+  [%expect {|
+    unboundZ : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv lambda capturing outer var (no free var)" =
+  let expr =
+    let_in (var "a") ~rhs:(nat 10)
+      ~in_:
+        (lambda (var "x", nat_ty)
+           ~body:(add (variable (var "x") nat_ty)
+                       (variable (var "a") nat_ty)))
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv lambda referencing free var (one free var)" =
+  let expr =
+    lambda (var "x", nat_ty)
+      ~body:(add (variable (var "x") nat_ty) (variable (var "b") nat_ty))
+  in
+  print_free_vars expr;
+  [%expect {|
+    b : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv lambda_rec no free var" =
+  let expr =
+    lambda_rec (var "fact")
+      (var "n", nat_ty)
+      ~body:(
+        if_bool (le (variable (var "n") nat_ty) (nat 1))
+          ~then_:(nat 1)
+          ~else_:(mul (variable (var "n") nat_ty)
+                      (app (variable (var "fact") (function_ty nat_ty nat_ty))
+                           (sub (variable (var "n") nat_ty) (nat 1)))))
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv lambda_rec referencing a free var" =
+  let expr =
+    lambda_rec (var "f") (var "n", int_ty)
+      ~body:(
+        if_bool
+          (le (variable (var "n") int_ty) (int 0))
+          ~then_:(variable (var "outer_val") int_ty)
+          ~else_:(app (variable (var "f") (function_ty int_ty int_ty))
+                     (sub (variable (var "n") int_ty) (int 1)))
+      )
+  in
+  print_free_vars expr;
+  [%expect {|
+    outer_val : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+  let%expect_test "fv app no free var" =
+  let lam_expr =
+    lambda (var "x", nat_ty)
+      ~body:(add (variable (var "x") nat_ty) (nat 1))
+  in
+  let expr =
+    let_in (var "f") ~rhs:lam_expr
+      ~in_:(app (variable (var "f") (function_ty nat_ty nat_ty)) (nat 42))
+  in
+  print_free_vars expr;
+  [%expect {||}]
+
+let%expect_test "fv app with free var in abs" =
+  let lam_expr =
+    lambda (var "x", nat_ty)
+      ~body:(add (variable (var "x") nat_ty) (variable (var "glo") nat_ty))
+  in
+  let expr = app lam_expr (nat 100) in
+  print_free_vars expr;
+  [%expect {|
+    glo : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv app with free var in arg" =
+  let lam_expr =
+    lambda (var "x", int_ty)
+      ~body:(mul (variable (var "x") int_ty) (int 2))
+  in
+  let expr = app lam_expr (variable (var "argFree") int_ty) in
+  print_free_vars expr;
+  [%expect {|
+    argFree : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv const no free var" =
+  let expr = int 42 in
+  print_free_vars expr;
+  [%expect {||}]
+
+let%expect_test "fv prim no free var (e.g. Add of 2 constants)" =
+  let expr = add (int 1) (int 2) in
+  print_free_vars expr;
+  [%expect {||}]
+
+let%expect_test "fv prim with one free var in arg" =
+  let expr = eq (variable (var "x") nat_ty) (nat 3) in
+  print_free_vars expr;
+  [%expect {|
+    x : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv prim with multiple free vars in args" =
+  let expr = add (variable (var "x") int_ty) (variable (var "y") int_ty) in
+  print_free_vars expr;
+  [%expect {|
+    x : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content ""))))))), y : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv let_mut_in no free var" =
+  let expr =
+    let_mut_in (mut_var "m") ~rhs:(int 10)
+      ~in_:(assign (mut_var "m") (add (deref (mut_var "m") int_ty) (int 1)))
+  in
+  print_free_vars expr;
+  [%expect {||}]
+
+let%expect_test "fv let_mut_in free var in body" =
+  let expr =
+    let_mut_in (mut_var "mm") ~rhs:(nat 1)
+      ~in_:(assign (mut_var "mm")
+              (add (deref (mut_var "mm") nat_ty)
+                   (variable (var "z") nat_ty)))
+  in
+  print_free_vars expr;
+  [%expect {|
+    z : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv let_mut_in free var in rhs" =
+  let expr =
+    let_mut_in (mut_var "mm") ~rhs:(variable (var "x") int_ty)
+      ~in_:(deref (mut_var "mm") int_ty)
+  in
+  print_free_vars expr;
+  [%expect {|
+    x : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv deref no free var" =
+  let expr =
+    let_mut_in (mut_var "mm") ~rhs:(nat 3)
+      ~in_:(deref (mut_var "mm") nat_ty)
+  in
+  print_free_vars expr;
+  [%expect {||}]
+
+let%expect_test "fv deref is free" =
+  let expr = deref (mut_var "mm") int_ty in
+  print_free_vars expr;
+  [%expect {|
+    mm : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv mutable var assignment (one free var)" =
+  let expr =
+    let_mut_in (mut_var "m") ~rhs:(nat 99)
+      ~in_:(assign (mut_var "m")
+              (add (deref (mut_var "m") nat_ty)
+                   (variable (var "x") nat_ty)))
+  in
+  print_free_vars expr;
+  [%expect {|
+    x : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv mutable var assignment no free var" =
+  let expr =
+    let_in (var "outer") ~rhs:(nat 2)
+      ~in_:
+        (let_mut_in (mut_var "m") ~rhs:(nat 99)
+          ~in_:(assign (mut_var "m")
+                  (add (deref (mut_var "m") nat_ty)
+                       (variable (var "outer") nat_ty))))
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv if_none capturing var in some branch (no free var)" =
+  let expr =
+    let_in (var "c") ~rhs:(nat 999)
+      ~in_:
+        (if_none (some (int 5))
+          ~none:(nat 0)
+          ~some:{
+            lam_var = (var "k", int_ty);
+            body = add (variable (var "k") int_ty) (variable (var "c") nat_ty)
+          })
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv if_none referencing free var in none branch" =
+  let expr =
+    if_none (some (int 5))
+      ~none:(add (int 0) (variable (var "unb") nat_ty))
+      ~some:{
+        lam_var=(var "k",int_ty);
+        body=(int 999)
+      }
+  in
+  print_free_vars expr;
+  [%expect {|
+    unb : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv if_cons referencing an unbound var" =
+  let lst = cons (nat 2) (cons (nat 4) (nil nat_ty)) in
+  let expr =
+    if_cons lst
+      ~empty:(int 0)
+      ~nonempty:{
+        lam_var1 = (var "hd", nat_ty);
+        lam_var2 = (var "tl", list_ty nat_ty);
+        body = add (variable (var "hd") nat_ty)
+                   (variable (var "some_free_var") nat_ty)
+      }
+  in
+  print_free_vars expr;
+  [%expect {|
+    some_free_var : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv if_cons no free var" =
+  let lst = nil nat_ty in
+  let expr =
+    if_cons lst
+      ~empty:(nat 999)
+      ~nonempty:{
+        lam_var1=(var "hd", nat_ty);
+        lam_var2=(var "tl", list_ty nat_ty);
+        body=add (variable (var "hd") nat_ty) (nat 1)
+      }
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv if_left overshadow var (no free var)" =
+  let left_expr = left (None, None, bool_ty) (bool true) in
+  let expr =
+    if_left left_expr
+      ~left:{
+        lam_var = (var "flag", bool_ty);
+        body = let_in (var "flag") ~rhs:(bool false)
+                ~in_:(variable (var "flag") bool_ty)
+      }
+      ~right:{
+        lam_var = (var "x", bool_ty);
+        body = bool false
+      }
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv if_left right branch free var" =
+  let left_expr = left (None, None, bool_ty) (bool true) in
+  let expr =
+    if_left left_expr
+      ~left:{
+        lam_var = (var "flag", bool_ty);
+        body = bool true
+      }
+      ~right:{
+        lam_var = (var "x", bool_ty);
+        body = add (nat 0) (variable (var "unbound_ifleft") int_ty)
+      }
+  in
+  print_free_vars expr;
+  [%expect {|
+    unbound_ifleft : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv if_bool same free var in both branches" =
+  let condition = gt (variable (var "x") int_ty) (int 0) in
+  let expr =
+    if_bool condition
+      ~then_:(add (variable (var "x") int_ty) (int 1))
+      ~else_:(sub (variable (var "x") int_ty) (int 1))
+  in
+  print_free_vars expr;
+  [%expect {|
+    x : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv if_bool with distinct free vars in each branch" =
+  let condition = bool true in
+  let expr =
+    if_bool condition
+      ~then_:(add (variable (var "varA") nat_ty) (nat 10))
+      ~else_:(mul (variable (var "varB") nat_ty) (nat 2))
+  in
+  print_free_vars expr;
+  [%expect {|
+    varA : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content ""))))))), varB : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv nested if_bool overshadow" =
+  let expr =
+    let_in (var "x") ~rhs:(int 1)
+      ~in_:
+        (if_bool (eq (variable (var "x") int_ty) (int 1))
+          ~then_:
+            (let_in (var "x") ~rhs:(int 2)
+              ~in_:(add (variable (var "x") int_ty)
+                         (variable (var "outer") int_ty)))
+          ~else_:
+            (add (variable (var "x") int_ty)
+                (variable (var "outer2") int_ty)))
+  in
+  print_free_vars expr;
+  [%expect {|
+    outer : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content ""))))))), outer2 : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv for with multiple free vars" =
+  let mut_x = mut_var "x" in
+  let expr =
+    let_mut_in mut_x ~rhs:(int 10)
+      ~in_:
+        (for_ (mut_var "i")
+          ~init:(variable (var "freeVarInit") int_ty)
+          ~cond:(lt (deref (mut_var "i") int_ty)
+                    (variable (var "freeCond") int_ty))
+          ~update:(assign (mut_var "i") (add (deref (mut_var "i") int_ty) (int 1)))
+          ~body:(
+            assign mut_x
+              (add (deref mut_x int_ty)
+                   (add (deref (mut_var "i") int_ty)
+                        (variable (var "freeBody") int_ty)))
+          ))
+  in
+  print_free_vars expr;
+  [%expect {|
+    freeBody : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content ""))))))), freeCond : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content ""))))))), freeVarInit : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv for no free vars" =
+  let mut_x = mut_var "x" in
+  let expr =
+    let_mut_in mut_x ~rhs:(int 0)
+      ~in_:
+        (for_ (mut_var "i")
+          ~init:(int 1)
+          ~cond:(lt (deref (mut_var "i") int_ty) (int 3))
+          ~update:(assign (mut_var "i") (add (deref (mut_var "i") int_ty) (int 1)))
+          ~body:(assign mut_x (add (deref mut_x int_ty) (deref (mut_var "i") int_ty))))
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv for_each referencing outer var" =
+  let list_expr = cons (int 1) (cons (int 2) (nil int_ty)) in
+  let expr =
+    let_in (var "outer") ~rhs:(int 10)
+      ~in_:
+        (for_each list_expr ~body:{
+          lam_var = (var "elem", int_ty);
+          body = add (variable (var "elem") int_ty)
+                     (variable (var "outer") int_ty)
+        })
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv for_each body free var" =
+  let list_expr = cons (int 1) (nil int_ty) in
+  let expr =
+    for_each list_expr ~body:{
+      lam_var=(var "el", int_ty);
+      body=add (variable (var "el") int_ty) (variable (var "unboundFe") int_ty)
+    }
+  in
+  print_free_vars expr;
+  [%expect {|
+    unboundFe : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv map overshadowing var (no free var)" =
+  let list_expr = cons (string "a") (cons (string "b") (nil string_ty)) in
+  let expr =
+    let_in (var "s") ~rhs:(string "outerS")
+      ~in_:
+        (map list_expr ~map:{
+          lam_var = (var "s", string_ty);
+          body = concat1 (variable (var "s") string_ty)
+                         (variable (var "s") string_ty)
+        })
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv map body free var" =
+  let list_expr = cons (nat 1) (cons (nat 2) (nil nat_ty)) in
+  let expr =
+    map list_expr ~map:{
+      lam_var=(var "n", nat_ty);
+      body=add (variable (var "n") nat_ty) (variable (var "unboundMap") nat_ty)
+    }
+  in
+  print_free_vars expr;
+  [%expect {|
+    unboundMap : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv fold_right referencing an unbound var in fold body" =
+  let lst = cons (nat 1) (cons (nat 2) (nil nat_ty)) in
+  let expr =
+    fold_right lst ~init:(nat 0)
+      ~fold:{
+        lam_var = (var "elem_acc", tuple_ty (mk_row [
+          Leaf(None, nat_ty); Leaf(None, nat_ty)
+        ]));
+        body = add
+          (car (variable (var "elem_acc") (tuple_ty (mk_row [
+            Leaf(None, nat_ty); Leaf(None, nat_ty)
+          ]))))
+          (add
+             (cdr (variable (var "elem_acc") (tuple_ty (mk_row [
+               Leaf(None, nat_ty); Leaf(None, nat_ty)
+             ]))))
+             (variable (var "unbound") nat_ty))
+      }
+  in
+  print_free_vars expr;
+  [%expect {|
+    unbound : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv fold_right no free var" =
+  let lst = cons (nat 1) (nil nat_ty) in
+  let expr =
+    fold_right lst ~init:(nat 0)
+      ~fold:{
+        lam_var=(var "pair", tuple_ty (mk_row [
+          Leaf(None,nat_ty); Leaf(None,nat_ty)
+        ]));
+        body=add
+          (car (variable (var "pair") (mk_tuple_ty [nat_ty; nat_ty])))
+               (cdr (variable (var "pair") (mk_tuple_ty [nat_ty; nat_ty])))
+      }
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv fold_left no free var" =
+let coll = cons (nat 1) (cons (nat 2) (nil nat_ty)) in
+let expr =
+  fold_left coll ~init:(nat 0)
+    ~fold:{
+      lam_var = (var "acc_x", tuple_ty (mk_row [
+        Leaf(None, nat_ty);
+        Leaf(None, nat_ty)
+      ]));
+      body = add
+        (car (variable (var "acc_x") (tuple_ty (mk_row [
+          Leaf(None, nat_ty); Leaf(None, nat_ty)
+        ]))))
+        (cdr (variable (var "acc_x") (tuple_ty (mk_row [
+          Leaf(None, nat_ty); Leaf(None, nat_ty)
+        ]))))
+    }
+in
+print_free_vars expr;
+[%expect {|
+  |}]
+  
+let%expect_test "fv fold_left free var in body" =
+  let coll = cons (nat 1) (cons (nat 2) (nil nat_ty)) in
+  let expr =
+    fold_left coll ~init:(nat 0)
+      ~fold:{
+        lam_var = (var "acc_x", tuple_ty (mk_row [
+          Leaf(None, nat_ty);
+          Leaf(None, nat_ty)
+        ]));
+        body = add
+          (add
+             (car (variable (var "acc_x") (mk_tuple_ty [nat_ty; nat_ty])))
+             (cdr (variable (var "acc_x") (mk_tuple_ty [nat_ty; nat_ty]))))
+          (variable (var "freeFold") nat_ty)
+      }
+  in
+  print_free_vars expr;
+  [%expect {|
+    freeFold : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv let_tuple_in overshadow (no free var)" =
+  let triple =
+    tuple (mk_row [
+      Leaf(None, nat 1);
+      Leaf(None, nat 2);
+      Leaf(None, nat 3)
+    ])
+  in
+  let expr =
+    let_in (var "x") ~rhs:(nat 999)
+      ~in_:
+        (let_tuple_in [var "x"; var "y"; var "z"]
+          ~rhs:triple
+          ~in_:(add (variable (var "x") nat_ty) (variable (var "x") nat_ty)))
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv let_tuple_in body free var" =
+  let triple =
+    tuple (mk_row [
+      Leaf(None, int 10);
+      Leaf(None, int 20);
+      Leaf(None, int 30)
+    ])
+  in
+  let expr =
+    let_tuple_in [var "a"; var "b"; var "c"]
+      ~rhs:triple
+      ~in_:(add (variable (var "c") int_ty)
+                (variable (var "notBound") int_ty))
+  in
+  print_free_vars expr;
+  [%expect {|
+    notBound : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv proj referencing free var" =
+  let triple =
+    tuple (mk_row [
+      Leaf(None, nat 1);
+      Leaf(None, nat 2);
+      Leaf(None, nat 3)
+    ])
+  in
+  let second_elem = proj triple ~path:(Here [1]) in
+  let expr = add second_elem (variable (var "outer") nat_ty) in
+  print_free_vars expr;
+  [%expect {|
+    outer : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv proj fully bound, no free var" =
+  let triple =
+    let_in (var "a") ~rhs:(nat 10)
+      ~in_:
+        (tuple (mk_row [
+          Leaf(None, variable (var "a") nat_ty);
+          Leaf(None, nat 11);
+          Leaf(None, nat 12)
+        ]))
+  in
+  let second_elem = proj triple ~path:(Here [1]) in
+  let expr = add second_elem (nat 100) in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv create_contract referencing outer var (no free var leftover)" =
+  let storage_ty = nat_ty in
+  let param_storage_ty = mk_tuple_ty [nat_ty; storage_ty] in
+  let code_lam =
+    let_tuple_in [var "p"; var "s"]
+      ~rhs:(variable (var "args") param_storage_ty)
+      ~in_:(tuple (mk_row [
+        Leaf(None, nil (operation_ty));
+        Leaf(None, add (variable (var "p") nat_ty)
+                       (variable (var "big_val") nat_ty))
+      ]))
+  in
+  let expr =
+    let_in (var "big_val") ~rhs:(nat 9999)
+      ~in_:
+        (create_contract
+          ~storage:storage_ty
+          ~code:{ lam_var=(var "args", param_storage_ty); body=code_lam }
+          ~delegate:(none key_hash_ty)
+          ~initial_balance:(mutez 1000)
+          ~initial_storage:(nat 0))
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv create_contract referencing unbound var in code" =
+  let storage_ty = nat_ty in
+  let param_storage_ty = mk_tuple_ty [int_ty; storage_ty] in
+  let code_lam =
+    let_tuple_in [var "p"; var "s"]
+      ~rhs:(variable (var "args") param_storage_ty)
+      ~in_:(tuple (mk_row [
+        Leaf(None, nil (operation_ty));
+        Leaf(None, add (variable (var "p") int_ty)
+                       (variable (var "freeU") nat_ty))
+      ]))
+  in
+  let expr =
+    create_contract
+      ~storage:storage_ty
+      ~code:{ lam_var=(var "args", param_storage_ty); body=code_lam }
+      ~delegate:(none key_hash_ty)
+      ~initial_balance:(mutez 1000)
+      ~initial_storage:(nat 0)
+  in
+  print_free_vars expr;
+  [%expect {|
+    freeU : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let michelson_push_int n = Tezos_micheline.Micheline.Prim (Ast_builder.Dummy_range.v, "PUSH", [Tezos_micheline.Micheline.Int (Ast_builder.Dummy_range.v, Z.of_int n)], [])
+let%expect_test "fv raw_michelson no arguments" =
+  let michelson_ast =
+    Tezos_micheline.Micheline.Seq (Ast_builder.Dummy_range.v, [michelson_push_int 42])
+  in
+  let expr =
+    raw_michelson michelson_ast [] (int_ty)
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv raw_michelson single free var in argument" =
+  let michelson_ast =
+    Tezos_micheline.Micheline.Seq (Ast_builder.Dummy_range.v, [michelson_push_int 100])
+  in
+  let expr =
+    raw_michelson michelson_ast
+      [variable (var "freeArg") int_ty]
+      int_ty
+  in
+  print_free_vars expr;
+  [%expect {|
+    freeArg : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv raw_michelson mixed arguments" =
+  let michelson_ast =
+    Tezos_micheline.Micheline.Seq (Ast_builder.Dummy_range.v, [michelson_push_int 999])
+  in
+  let expr =
+    let_in (var "x") ~rhs:(int 123)
+      ~in_:
+        (raw_michelson michelson_ast
+          [
+            variable (var "x") int_ty;
+            variable (var "unboundVar") int_ty
+          ]
+          int_ty)
+  in
+  print_free_vars expr;
+  [%expect {|
+    unboundVar : ((desc Int)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]
+
+let%expect_test "fv raw_michelson all bound arguments" =
+  let michelson_ast =
+    Tezos_micheline.Micheline.Seq (Ast_builder.Dummy_range.v, [michelson_push_int 1])
+  in
+  let expr =
+    let_in (var "a") ~rhs:(int 10)
+      ~in_:
+        (let_in (var "b") ~rhs:(int 20)
+          ~in_:
+            (raw_michelson michelson_ast
+              [
+                variable (var "a") int_ty;
+                variable (var "b") int_ty
+              ]
+              int_ty))
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv global_constant no free var" =
+  let expr =
+    global_constant "someHash" [int 10] int_ty
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv global_constant referencing outer var" =
+  let expr =
+    let_in (var "outer") ~rhs:(int 42)
+      ~in_:
+        (global_constant "expruHash" [variable (var "outer") int_ty] int_ty)
+  in
+  print_free_vars expr;
+  [%expect {|
+    |}]
+
+let%expect_test "fv global_constant unbound var" =
+  let expr =
+    global_constant "hashX" [variable (var "unG") nat_ty; nat 9] nat_ty
+  in
+  print_free_vars expr;
+  [%expect {|
+    unG : ((desc Nat)
+     (range ((start 0) (stop 0) (source (String ((name ("")) (content "")))))))
+  |}]

--- a/test/test_last_vars.ml
+++ b/test/test_last_vars.ml
@@ -1,0 +1,3838 @@
+open Core
+open Lltz_ir
+open Ast_builder.With_dummy
+module LV = Lltz_codegen.Last_vars
+module Michelson_base = Michelson_base
+
+let rec print_annotations ?(indent=0) (e : Expr.t) =
+  let pad = String.make indent ' ' in
+  let lu_str =
+    Set.to_list e.annotations.last_used_vars
+    |> String.concat ~sep:", "
+  in
+  let rnu_str =
+    Set.to_list e.annotations.remove_never_used_vars
+    |> String.concat ~sep:", "
+  in
+  let print_intro label =
+    Printf.printf "%sNode: %s\n" pad label;
+    Printf.printf "%s  luv = {%s} nuv = {%s} \n" pad lu_str rnu_str; (*luv - last_used_vars, nuv - never_used_vars*)
+  in
+
+  match e.desc with
+  | Expr.Let_in { let_var = Var x; rhs; in_ } ->
+    print_intro "Let_in";
+    Printf.printf "%s  let_var=%s\n" pad x;
+    Printf.printf "%s  rhs:\n" pad;
+    print_annotations ~indent:(indent+2) rhs;
+    Printf.printf "%s  in_:\n" pad;
+    print_annotations ~indent:(indent+2) in_
+
+  | Expr.Let_mut_in { let_var = Mut_var x; rhs; in_ } ->
+    print_intro "Let_mut_in";
+    Printf.printf "%s  let_var=%s\n" pad x;
+    Printf.printf "%s  rhs:\n" pad;
+    print_annotations ~indent:(indent+2) rhs;
+    Printf.printf "%s  in_:\n" pad;
+    print_annotations ~indent:(indent+2) in_
+
+  | Expr.Lambda_rec { mu_var = (Var mu, _mu_ty); lambda = { lam_var = (Var arg, _arg_ty); body } } ->
+    print_intro "Lambda_rec";
+    Printf.printf "%s  mu_var=%s\n" pad mu;
+    Printf.printf "%s  lam_var=%s\n" pad arg;
+    Printf.printf "%s  body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.Lambda { lam_var = (Var arg, _arg_ty); body } ->
+    print_intro "Lambda";
+    Printf.printf "%s  lam_var=%s\n" pad arg;
+    Printf.printf "%s  body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.App { abs; arg } ->
+    print_intro "App";
+    Printf.printf "%s  abs:\n" pad;
+    print_annotations ~indent:(indent+2) abs;
+    Printf.printf "%s  arg:\n" pad;
+    print_annotations ~indent:(indent+2) arg
+
+  | Expr.Const _ ->
+    print_intro "Const";
+
+  | Expr.Prim (_, args) ->
+    print_intro "Prim";
+    Printf.printf "%s  args:\n" pad;
+    List.iter ~f:(fun x -> print_annotations ~indent:(indent+2) x) args
+
+  | Expr.Assign (Mut_var x, v) ->
+    print_intro "Assign";
+    Printf.printf "%s  let_var=%s\n" pad x;
+    Printf.printf "%s  value:\n" pad;
+    print_annotations ~indent:(indent+2) v
+
+  | Expr.If_bool { condition; if_true; if_false } ->
+    print_intro "If_bool";
+    Printf.printf "%s  condition:\n" pad;
+    print_annotations ~indent:(indent+2) condition;
+    Printf.printf "%s  if_true:\n" pad;
+    print_annotations ~indent:(indent+2) if_true;
+    Printf.printf "%s  if_false:\n" pad;
+    print_annotations ~indent:(indent+2) if_false
+
+  | Expr.If_none { subject; if_none; if_some={lam_var=(Var x,_ty); body} } ->
+    print_intro "If_none";
+    Printf.printf "%s  subject:\n" pad;
+    print_annotations ~indent:(indent+2) subject;
+    Printf.printf "%s  if_none:\n" pad;
+    print_annotations ~indent:(indent+2) if_none;
+    Printf.printf "%s  if_some lam_var=%s\n" pad x;
+    Printf.printf "%s  if_some body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.If_cons { subject; if_empty; if_nonempty={lam_var1=(Var hd,_ty1); lam_var2=(Var tl,_ty2); body} } ->
+    print_intro "If_cons";
+    Printf.printf "%s  subject:\n" pad;
+    print_annotations ~indent:(indent+2) subject;
+    Printf.printf "%s  if_empty:\n" pad;
+    print_annotations ~indent:(indent+2) if_empty;
+    Printf.printf "%s  if_nonempty lam_var1=%s lam_var2=%s\n" pad hd tl;
+    Printf.printf "%s  if_nonempty body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.If_left { subject; if_left={lam_var=(Var xl,_tyl); body=bl}; if_right={lam_var=(Var xr,_tyr); body=br} } ->
+    print_intro "If_left";
+    Printf.printf "%s  subject:\n" pad;
+    print_annotations ~indent:(indent+2) subject;
+    Printf.printf "%s  if_left lam_var=%s\n" pad xl;
+    print_annotations ~indent:(indent+2) bl;
+    Printf.printf "%s  if_right lam_var=%s\n" pad xr;
+    print_annotations ~indent:(indent+2) br
+
+  | Expr.While { cond; body } ->
+    print_intro "While";
+    Printf.printf "%s  cond:\n" pad;
+    print_annotations ~indent:(indent+2) cond;
+    Printf.printf "%s  body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.While_left { cond; body={lam_var=(Var x,_ty); body} } ->
+    print_intro "While_left";
+    Printf.printf "%s  cond:\n" pad;
+    print_annotations ~indent:(indent+2) cond;
+    Printf.printf "%s  lam_var=%s\n" pad x;
+    Printf.printf "%s  body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.For { index = Mut_var idx; init; cond; update; body } ->
+    print_intro "For";
+    Printf.printf "%s  index=%s\n" pad idx;
+    Printf.printf "%s  init:\n" pad;
+    print_annotations ~indent:(indent+2) init;
+    Printf.printf "%s  cond:\n" pad;
+    print_annotations ~indent:(indent+2) cond;
+    Printf.printf "%s  update:\n" pad;
+    print_annotations ~indent:(indent+2) update;
+    Printf.printf "%s  body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.For_each { collection; body={lam_var=(Var x,_ty); body} } ->
+    print_intro "For_each";
+    Printf.printf "%s  collection:\n" pad;
+    print_annotations ~indent:(indent+2) collection;
+    Printf.printf "%s  lam_var=%s\n" pad x;
+    Printf.printf "%s  body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.Map { collection; map={lam_var=(Var x,_ty); body} } ->
+    print_intro "Map";
+    Printf.printf "%s  collection:\n" pad;
+    print_annotations ~indent:(indent+2) collection;
+    Printf.printf "%s  lam_var=%s\n" pad x;
+    Printf.printf "%s  body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.Fold_left { collection; init; fold={lam_var=(Var x,_ty); body} } ->
+    print_intro "Fold_left";
+    Printf.printf "%s  collection:\n" pad;
+    print_annotations ~indent:(indent+2) collection;
+    Printf.printf "%s  init:\n" pad;
+    print_annotations ~indent:(indent+2) init;
+    Printf.printf "%s  lam_var=%s\n" pad x;
+    Printf.printf "%s  body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.Fold_right { collection; init; fold={lam_var=(Var x,_ty); body} } ->
+    print_intro "Fold_right";
+    Printf.printf "%s  collection:\n" pad;
+    print_annotations ~indent:(indent+2) collection;
+    Printf.printf "%s  init:\n" pad;
+    print_annotations ~indent:(indent+2) init;
+    Printf.printf "%s  lam_var=%s\n" pad x;
+    Printf.printf "%s  body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.Let_tuple_in { components; rhs; in_ } ->
+    print_intro "Let_tuple_in";
+    Printf.printf "%s  components=[%s]\n" pad
+      (String.concat ~sep:";" (List.map components ~f:(fun (Var v) -> v)));
+    Printf.printf "%s  rhs:\n" pad;
+    print_annotations ~indent:(indent+2) rhs;
+    Printf.printf "%s  in_:\n" pad;
+    print_annotations ~indent:(indent+2) in_
+
+  | Expr.Tuple row ->
+    print_intro "Tuple";
+    let rec visit_row row =
+      match row with
+      | Row.Node sub ->
+        List.iter ~f:visit_row sub
+      | Row.Leaf (lbl, e) ->
+        let lbl_str = match lbl with
+          | Some (Row.Label s) -> s
+          | None -> "<no-label>"
+        in
+        Printf.printf "%s  Leaf label=%s\n" pad lbl_str;
+        print_annotations ~indent:(indent+2) e
+    in
+    visit_row row
+
+  | Expr.Proj (tup, _) ->
+    print_intro "Proj";
+    print_annotations ~indent:(indent+2) tup
+
+  | Expr.Update { tuple; update; _ } ->
+    print_intro "Update";
+    Printf.printf "%s  tuple:\n" pad;
+    print_annotations ~indent:(indent+2) tuple;
+    Printf.printf "%s  update:\n" pad;
+    print_annotations ~indent:(indent+2) update
+
+  | Expr.Raw_michelson { args; _ } ->
+    print_intro "Raw_michelson";
+    Printf.printf "%s  args:\n" pad;
+    List.iter ~f:(fun x -> print_annotations ~indent:(indent+2) x) args
+
+  | Expr.Create_contract { code = { lam_var=(Var lamv,_ty); body }; delegate; initial_balance; initial_storage; _ } ->
+    print_intro "Create_contract";
+    Printf.printf "%s  lam_var=%s\n" pad lamv;
+    Printf.printf "%s  delegate:\n" pad;
+    print_annotations ~indent:(indent+2) delegate;
+    Printf.printf "%s  initial_balance:\n" pad;
+    print_annotations ~indent:(indent+2) initial_balance;
+    Printf.printf "%s  initial_storage:\n" pad;
+    print_annotations ~indent:(indent+2) initial_storage;
+    Printf.printf "%s  code body:\n" pad;
+    print_annotations ~indent:(indent+2) body
+
+  | Expr.Global_constant { hash; args } ->
+    print_intro "Global_constant";
+    Printf.printf "%s  hash=%s\n" pad hash;
+    Printf.printf "%s  args:\n" pad;
+    List.iter ~f:(fun x -> print_annotations ~indent:(indent+2) x) args
+
+  | Expr.Deref (Mut_var x) ->
+    print_intro "Deref";
+    Printf.printf "%s  mut_var=%s\n" pad x
+
+  | Expr.Variable (Var v) ->
+    print_intro "Variable";
+    Printf.printf "%s  var=%s\n" pad v
+
+  | Expr.Inj _ ->
+    print_intro "Inj (skipped printing details)"
+
+  | Expr.Match _ ->
+    print_intro "Match (skipped printing details)"
+
+let test_and_print title expr =
+  Printf.printf "\n--- %s ---\n" title;
+  let result = LV.compute_last_vars expr in
+  print_annotations result;
+  Printf.printf "\n";
+  Test_nodes.test_expr expr
+
+(* -------------------------------------------------------------------- *)
+
+let%expect_test "assign same var multiple branches" =
+  let mut_x = mut_var "x" in
+  let condition = eq (deref mut_x nat_ty) (nat 100) in
+  let then_branch =
+    assign mut_x (sub (deref mut_x nat_ty) (nat 50))
+  in
+  let else_branch =
+    assign mut_x (sub (deref mut_x nat_ty) (nat 10))
+  in
+  let expr =
+    let_mut_in mut_x ~rhs:(nat 100)
+      ~in_:
+        (if_bool condition
+          ~then_:then_branch
+          ~else_:else_branch)
+  in
+  test_and_print "assign same var multiple branches" expr;
+  [%expect {|
+    --- assign same var multiple branches ---
+    Node: Let_mut_in
+      luv = {x} nuv = {}
+      let_var=x
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: If_bool
+        luv = {x} nuv = {}
+        condition:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Deref
+              luv = {} nuv = {}
+              mut_var=x
+            Node: Const
+              luv = {} nuv = {}
+        if_true:
+        Node: Assign
+          luv = {x} nuv = {}
+          let_var=x
+          value:
+          Node: Prim
+            luv = {x} nuv = {}
+            args:
+            Node: Deref
+              luv = {x} nuv = {}
+              mut_var=x
+            Node: Const
+              luv = {} nuv = {}
+        if_false:
+        Node: Assign
+          luv = {x} nuv = {}
+          let_var=x
+          value:
+          Node: Prim
+            luv = {x} nuv = {}
+            args:
+            Node: Deref
+              luv = {x} nuv = {}
+              mut_var=x
+            Node: Const
+              luv = {} nuv = {}
+
+    { PUSH nat 100 ;
+      PUSH nat 100 ;
+      DUP 2 ;
+      COMPARE ;
+      EQ ;
+      IF { PUSH nat 50 ; SWAP ; SUB ; DROP ; UNIT }
+         { PUSH nat 10 ; SWAP ; SUB ; DROP ; UNIT } }
+
+    Optimised:
+    { PUSH nat 100 ;
+      DUP ;
+      DUP 2 ;
+      COMPARE ;
+      EQ ;
+      IF { PUSH int -50 ; ADD ; DROP } { PUSH int -10 ; ADD ; DROP } ;
+      UNIT } |}]
+
+let%expect_test "test_variable" =
+  let expr = variable (var "x") int_ty in
+  test_and_print "test_variable" expr;
+  [%expect {|
+    --- test_variable ---
+    Node: Variable
+      luv = {x} nuv = {}
+      var=x
+
+    { NEVER }
+
+    Optimised:
+    { NEVER } |}]
+
+let%expect_test "test_let_in" =
+  let expr =
+    let_in (var "x") ~rhs:(int 10)
+      ~in_:(let_in (var "x") ~rhs:(add (variable (var "x") int_ty) (int 1))
+         ~in_:(add (variable (var "x") int_ty) (variable (var "unused") int_ty)))
+  in
+  test_and_print "test_let_in" expr;
+  [%expect {|
+    --- test_let_in ---
+    Node: Let_in
+      luv = {unused, x} nuv = {}
+      let_var=x
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {unused, x} nuv = {}
+        let_var=x
+        rhs:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Variable
+            luv = {} nuv = {}
+            var=x
+          Node: Const
+            luv = {} nuv = {}
+        in_:
+        Node: Prim
+          luv = {unused, x} nuv = {}
+          args:
+          Node: Variable
+            luv = {x} nuv = {}
+            var=x
+          Node: Variable
+            luv = {unused} nuv = {}
+            var=unused
+
+    { PUSH int 10 ; PUSH int 1 ; DUP 2 ; ADD ; NEVER }
+
+    Optimised:
+    { PUSH int 10 ; PUSH int 1 ; DUP 2 ; ADD ; NEVER } |}]
+
+
+let%expect_test "let_in multiple references no overshadow" =
+  let expr =
+    let_in (var "varA") ~rhs:(int 10)
+      ~in_:(let_in (var "varB") ~rhs:(int 5)
+        ~in_:(add
+                (add (variable (var "varA") int_ty)
+                     (variable (var "varB") int_ty))
+                (variable (var "varA") int_ty)))
+  in
+  test_and_print "let_in multiple references no overshadow" expr;
+  [%expect {|
+    --- let_in multiple references no overshadow ---
+    Node: Let_in
+      luv = {varA, varB} nuv = {}
+      let_var=varA
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {varA, varB} nuv = {}
+        let_var=varB
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Prim
+          luv = {varA, varB} nuv = {}
+          args:
+          Node: Prim
+            luv = {varA, varB} nuv = {}
+            args:
+            Node: Variable
+              luv = {varA} nuv = {}
+              var=varA
+            Node: Variable
+              luv = {varB} nuv = {}
+              var=varB
+          Node: Variable
+            luv = {} nuv = {}
+            var=varA
+
+    { PUSH int 10 ; PUSH int 5 ; DUP 2 ; SWAP ; DIG 2 ; ADD ; ADD }
+
+    Optimised:
+    { PUSH int 10 ; PUSH int 5 ; DUP 2 ; SWAP ; DIG 2 ; ADD ; ADD } |}]
+
+let%expect_test "test_lambda" =
+  let expr =
+    let_in (var "outerVar") ~rhs:(int 7)
+      ~in_:
+        (lambda (var "a", int_ty)
+          ~body:(
+            add (variable (var "a") int_ty)
+                (variable (var "outerVar") int_ty)
+          ))
+  in
+  test_and_print "test_lambda" expr;
+  [%expect {|
+    --- test_lambda ---
+    Node: Let_in
+      luv = {a, outerVar} nuv = {}
+      let_var=outerVar
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Lambda
+        luv = {a, outerVar} nuv = {}
+        lam_var=a
+        body:
+        Node: Prim
+          luv = {a, outerVar} nuv = {}
+          args:
+          Node: Variable
+            luv = {a} nuv = {}
+            var=a
+          Node: Variable
+            luv = {outerVar} nuv = {}
+            var=outerVar
+
+    { PUSH int 7 ;
+      LAMBDA (pair int int) int { UNPAIR ; SWAP ; ADD } ;
+      SWAP ;
+      APPLY }
+
+    Optimised:
+    { LAMBDA (pair int int) int { UNPAIR ; ADD } ; PUSH int 7 ; APPLY } |}]
+
+let%expect_test "multiple lambdas referencing external vars" =
+  let expr =
+    let_in (var "y") ~rhs:(int 99)
+      ~in_:
+        (let_in (var "f")
+          ~rhs:(
+            lambda (var "a", int_ty)
+              ~body:(add (variable (var "a") int_ty) (variable (var "y") int_ty))
+          )
+          ~in_:
+            (let_in (var "g")
+              ~rhs:(
+                lambda (var "a", int_ty)
+                  ~body:(
+                    add
+                      (app (variable (var "f") (function_ty int_ty int_ty))
+                           (mul (variable (var "a") int_ty) (int 2)))
+                      (variable (var "y") int_ty)
+                  )
+              )
+              ~in_:(app (variable (var "g") (function_ty int_ty int_ty)) (int 10))))
+  in
+  test_and_print "multiple lambdas referencing external vars" expr;
+  [%expect {|
+    --- multiple lambdas referencing external vars ---
+    Node: Let_in
+      luv = {a, f, g, y} nuv = {}
+      let_var=y
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {a, f, g, y} nuv = {}
+        let_var=f
+        rhs:
+        Node: Lambda
+          luv = {a} nuv = {}
+          lam_var=a
+          body:
+          Node: Prim
+            luv = {a} nuv = {}
+            args:
+            Node: Variable
+              luv = {a} nuv = {}
+              var=a
+            Node: Variable
+              luv = {} nuv = {}
+              var=y
+        in_:
+        Node: Let_in
+          luv = {a, f, g, y} nuv = {}
+          let_var=g
+          rhs:
+          Node: Lambda
+            luv = {a, f, y} nuv = {}
+            lam_var=a
+            body:
+            Node: Prim
+              luv = {a, f, y} nuv = {}
+              args:
+              Node: App
+                luv = {a, f} nuv = {}
+                abs:
+                Node: Variable
+                  luv = {f} nuv = {}
+                  var=f
+                arg:
+                Node: Prim
+                  luv = {a} nuv = {}
+                  args:
+                  Node: Variable
+                    luv = {a} nuv = {}
+                    var=a
+                  Node: Const
+                    luv = {} nuv = {}
+              Node: Variable
+                luv = {y} nuv = {}
+                var=y
+          in_:
+          Node: App
+            luv = {g} nuv = {}
+            abs:
+            Node: Variable
+              luv = {g} nuv = {}
+              var=g
+            arg:
+            Node: Const
+              luv = {} nuv = {}
+
+    { PUSH int 99 ;
+      LAMBDA (pair int int) int { UNPAIR ; DUP 1 ; DIG 2 ; ADD ; SWAP ; DROP } ;
+      DUP 2 ;
+      APPLY ;
+      LAMBDA
+        (pair (lambda int int) (pair int int))
+        int
+        { UNPAIR 3 ; SWAP ; PUSH int 2 ; DIG 3 ; MUL ; DIG 2 ; SWAP ; EXEC ; ADD } ;
+      SWAP ;
+      APPLY ;
+      SWAP ;
+      APPLY ;
+      PUSH int 10 ;
+      SWAP ;
+      SWAP ;
+      EXEC }
+
+    Optimised:
+    { PUSH int 99 ;
+      LAMBDA (pair int int) int { UNPAIR ; ADD } ;
+      DUP 2 ;
+      APPLY ;
+      LAMBDA
+        (pair (lambda int int) (pair int int))
+        int
+        { UNPAIR 3 ; SWAP ; PUSH int 2 ; DIG 3 ; MUL ; DIG 2 ; SWAP ; EXEC ; ADD } ;
+      SWAP ;
+      APPLY ;
+      SWAP ;
+      APPLY ;
+      PUSH int 10 ;
+      EXEC } |}]
+
+let%expect_test "lambda referencing multiple distinct outside vars" =
+  let expr =
+    let_in (var "a") ~rhs:(int 1)
+      ~in_:
+        (let_in (var "b") ~rhs:(int 2)
+          ~in_:
+            (lambda (var "x", int_ty)
+              ~body:(add
+                       (variable (var "x") int_ty)
+                       (add (variable (var "a") int_ty) (variable (var "b") int_ty)))))
+  in
+  test_and_print "lambda referencing multiple distinct outside vars" expr;
+  [%expect {|
+    --- lambda referencing multiple distinct outside vars ---
+    Node: Let_in
+      luv = {a, b, x} nuv = {}
+      let_var=a
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {a, b, x} nuv = {}
+        let_var=b
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Lambda
+          luv = {a, b, x} nuv = {}
+          lam_var=x
+          body:
+          Node: Prim
+            luv = {a, b, x} nuv = {}
+            args:
+            Node: Variable
+              luv = {x} nuv = {}
+              var=x
+            Node: Prim
+              luv = {a, b} nuv = {}
+              args:
+              Node: Variable
+                luv = {a} nuv = {}
+                var=a
+              Node: Variable
+                luv = {b} nuv = {}
+                var=b
+
+    { PUSH int 1 ;
+      PUSH int 2 ;
+      LAMBDA
+        (pair int (pair int int))
+        int
+        { UNPAIR 3 ; SWAP ; SWAP ; ADD ; SWAP ; ADD } ;
+      DIG 2 ;
+      APPLY ;
+      SWAP ;
+      APPLY }
+
+    Optimised:
+    { PUSH int 1 ;
+      PUSH int 2 ;
+      LAMBDA (pair int (pair int int)) int { UNPAIR 3 ; ADD ; ADD } ;
+      DIG 2 ;
+      APPLY ;
+      SWAP ;
+      APPLY } |}]
+
+let%expect_test "test_lambda_rec" =
+  let body_expr =
+    if_bool
+      (gt (variable (var "n") int_ty) (int 0))
+      ~then_:(app (variable (var "f") (function_ty int_ty int_ty))
+                 (sub (variable (var "n") int_ty) (int 1)))
+      ~else_:(variable (var "outer") int_ty)
+  in
+  let lam_rec_expr =
+    lambda_rec (var "f") (var "n", int_ty)
+      ~body:body_expr
+  in
+  let expr =
+    let_in (var "outer") ~rhs:(int 1)
+      ~in_:lam_rec_expr
+  in
+  test_and_print "test_lambda_rec" expr;
+  [%expect {|
+    --- test_lambda_rec ---
+    Node: Let_in
+      luv = {f, n, outer} nuv = {}
+      let_var=outer
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Lambda_rec
+        luv = {f, n} nuv = {}
+        mu_var=f
+        lam_var=n
+        body:
+        Node: If_bool
+          luv = {f, n, outer} nuv = {}
+          condition:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Variable
+                luv = {} nuv = {}
+                var=n
+              Node: Const
+                luv = {} nuv = {}
+          if_true:
+          Node: App
+            luv = {f, n} nuv = {outer}
+            abs:
+            Node: Variable
+              luv = {f} nuv = {}
+              var=f
+            arg:
+            Node: Prim
+              luv = {n} nuv = {}
+              args:
+              Node: Variable
+                luv = {n} nuv = {}
+                var=n
+              Node: Const
+                luv = {} nuv = {}
+          if_false:
+          Node: Variable
+            luv = {outer} nuv = {f, n}
+            var=outer
+
+    { PUSH int 1 ;
+      LAMBDA_REC
+        (pair int int)
+        int
+        { UNPAIR ;
+          DIG 2 ;
+          DUP 2 ;
+          APPLY ;
+          DUG 2 ;
+          PUSH int 0 ;
+          DUP 3 ;
+          COMPARE ;
+          GT ;
+          IF { DROP ; PUSH int 1 ; SWAP ; SUB ; SWAP ; SWAP ; EXEC }
+             { DIG 2 ; DROP ; SWAP ; DROP } } ;
+      DUP 2 ;
+      APPLY ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { LAMBDA_REC
+        (pair int int)
+        int
+        { UNPAIR ;
+          DIG 2 ;
+          DUP 2 ;
+          APPLY ;
+          DUG 2 ;
+          DUP 2 ;
+          GT ;
+          IF { DROP ; PUSH int -1 ; ADD ; EXEC } { DUG 2 ; DROP 2 } } ;
+      PUSH int 1 ;
+      APPLY } |}]
+
+let%expect_test "test_app" =
+  let lam =
+    lambda (var "z", int_ty)
+      ~body:(add (variable (var "z") int_ty) (variable (var "unusedArg") int_ty))
+  in
+  let arg =
+    let_in (var "z") ~rhs:(int 999)
+      ~in_:(int 5)
+  in
+  let expr = app lam arg in
+  test_and_print "test_app" expr;
+  [%expect {|
+    --- test_app ---
+    Node: App
+      luv = {unusedArg, z} nuv = {}
+      abs:
+      Node: Lambda
+        luv = {unusedArg, z} nuv = {}
+        lam_var=z
+        body:
+        Node: Prim
+          luv = {unusedArg, z} nuv = {}
+          args:
+          Node: Variable
+            luv = {z} nuv = {}
+            var=z
+          Node: Variable
+            luv = {unusedArg} nuv = {}
+            var=unusedArg
+      arg:
+      Node: Let_in
+        luv = {z} nuv = {}
+        let_var=z
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Const
+          luv = {} nuv = {}
+
+    { PUSH int 999 ;
+      PUSH int 5 ;
+      SWAP ;
+      DROP ;
+      LAMBDA (pair int int) int { UNPAIR ; SWAP ; ADD } ;
+      NEVER }
+
+    Optimised:
+    { PUSH int 5 ; LAMBDA (pair int int) int { UNPAIR ; ADD } ; NEVER } |}]
+
+let%expect_test "partial apply overshadow f/g" =
+  let pair_ty = Ast_builder.With_dummy.mk_tuple_ty [int_ty; int_ty] in
+  let lam_f =
+    lambda (var "p", pair_ty)
+      ~body:(sub (car (variable (var "p") pair_ty))
+                 (cdr (variable (var "p") pair_ty)))
+  in
+  let expr =
+    let_in (var "f") ~rhs:lam_f
+      ~in_:
+        (let_in (var "g")
+          ~rhs:(apply (int 3) (variable (var "f") (function_ty pair_ty int_ty)))
+          ~in_:
+            (let_in (var "f") ~rhs:(int 999)
+              ~in_:
+                (exec (int 7) (variable (var "g") (function_ty int_ty int_ty)))))
+  in
+  test_and_print "partial apply overshadow f/g" expr;
+  [%expect {|
+    --- partial apply overshadow f/g ---
+    Node: Let_in
+      luv = {f, g, p} nuv = {}
+      let_var=f
+      rhs:
+      Node: Lambda
+        luv = {p} nuv = {}
+        lam_var=p
+        body:
+        Node: Prim
+          luv = {p} nuv = {}
+          args:
+          Node: Prim
+            luv = {p} nuv = {}
+            args:
+            Node: Variable
+              luv = {p} nuv = {}
+              var=p
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Variable
+              luv = {} nuv = {}
+              var=p
+      in_:
+      Node: Let_in
+        luv = {f, g} nuv = {}
+        let_var=g
+        rhs:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Const
+            luv = {} nuv = {}
+          Node: Variable
+            luv = {} nuv = {}
+            var=f
+        in_:
+        Node: Let_in
+          luv = {f, g} nuv = {}
+          let_var=f
+          rhs:
+          Node: Const
+            luv = {} nuv = {}
+          in_:
+          Node: Prim
+            luv = {g} nuv = {}
+            args:
+            Node: Const
+              luv = {} nuv = {}
+            Node: Variable
+              luv = {g} nuv = {}
+              var=g
+
+    { LAMBDA (pair int int) int { DUP 1 ; CDR ; SWAP ; CAR ; SUB } ;
+      DUP 1 ;
+      PUSH int 3 ;
+      APPLY ;
+      PUSH int 999 ;
+      SWAP ;
+      PUSH int 7 ;
+      EXEC ;
+      SWAP ;
+      DROP ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { LAMBDA (pair int int) int { UNPAIR ; SUB } ;
+      PUSH int 3 ;
+      APPLY ;
+      PUSH int 7 ;
+      EXEC } |}]
+
+let%expect_test "partial apply referencing outer var" =
+  let pair_ty = Ast_builder.With_dummy.mk_tuple_ty [int_ty; int_ty] in
+  let lamF =
+    lambda (var "p", pair_ty)
+      ~body:(
+        add
+          (car (variable (var "p") pair_ty))
+          (add (cdr (variable (var "p") pair_ty))
+               (variable (var "outerZ") int_ty))
+      )
+  in
+  let expr =
+    let_in (var "outerZ") ~rhs:(int 999)
+      ~in_:
+        (let_in (var "funF") ~rhs:lamF
+          ~in_:
+            (let_in (var "partial")
+              ~rhs:(apply (int 3) (variable (var "funF") (function_ty pair_ty int_ty)))
+              ~in_:(exec (int 7) (variable (var "partial") (function_ty int_ty int_ty)))))
+  in
+  test_and_print "partial apply referencing outer var" expr;
+  [%expect {|
+    --- partial apply referencing outer var ---
+    Node: Let_in
+      luv = {funF, outerZ, p, partial} nuv = {}
+      let_var=outerZ
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {funF, outerZ, p, partial} nuv = {}
+        let_var=funF
+        rhs:
+        Node: Lambda
+          luv = {outerZ, p} nuv = {}
+          lam_var=p
+          body:
+          Node: Prim
+            luv = {outerZ, p} nuv = {}
+            args:
+            Node: Prim
+              luv = {p} nuv = {}
+              args:
+              Node: Variable
+                luv = {p} nuv = {}
+                var=p
+            Node: Prim
+              luv = {outerZ} nuv = {}
+              args:
+              Node: Prim
+                luv = {} nuv = {}
+                args:
+                Node: Variable
+                  luv = {} nuv = {}
+                  var=p
+              Node: Variable
+                luv = {outerZ} nuv = {}
+                var=outerZ
+        in_:
+        Node: Let_in
+          luv = {funF, partial} nuv = {}
+          let_var=partial
+          rhs:
+          Node: Prim
+            luv = {funF} nuv = {}
+            args:
+            Node: Const
+              luv = {} nuv = {}
+            Node: Variable
+              luv = {funF} nuv = {}
+              var=funF
+          in_:
+          Node: Prim
+            luv = {partial} nuv = {}
+            args:
+            Node: Const
+              luv = {} nuv = {}
+            Node: Variable
+              luv = {partial} nuv = {}
+              var=partial
+
+    { PUSH int 999 ;
+      LAMBDA
+        (pair int (pair int int))
+        int
+        { UNPAIR ; DUP 2 ; CDR ; ADD ; SWAP ; CAR ; ADD } ;
+      SWAP ;
+      APPLY ;
+      PUSH int 3 ;
+      APPLY ;
+      PUSH int 7 ;
+      EXEC }
+
+    Optimised:
+    { LAMBDA
+        (pair int (pair int int))
+        int
+        { UNPAIR ; DUP 2 ; CDR ; ADD ; SWAP ; CAR ; ADD } ;
+      PUSH int 999 ;
+      APPLY ;
+      PUSH int 3 ;
+      APPLY ;
+      PUSH int 7 ;
+      EXEC } |}]
+
+let%expect_test "mixed let_in, let_mut_in, nested lambdas referencing overshadow" =
+  let mut_x = mut_var "x" in
+  let assign_x_outer =
+    assign mut_x (add (deref mut_x int_ty) (variable (var "outer") int_ty))
+  in
+  let lam_g =
+    lambda (var "z", int_ty)
+      ~body:(
+        let_in (var "ignore_g")
+          ~rhs:(assign mut_x (add (deref mut_x int_ty) (variable (var "z") int_ty)))
+          ~in_:(deref mut_x int_ty)
+      )
+  in
+  let lam_f =
+    lambda (var "n", int_ty)
+      ~body:(
+        let_in (var "g") ~rhs:lam_g
+          ~in_:(app (variable (var "g") (function_ty int_ty int_ty))
+                    (add (variable (var "n") int_ty) (variable (var "outer") int_ty)))
+      )
+  in
+  let expr =
+    let_in (var "outer") ~rhs:(int 10)
+      ~in_:
+        (let_mut_in mut_x ~rhs:(int 0)
+          ~in_:
+            (let_in (var "ignore1") ~rhs:assign_x_outer
+              ~in_:
+                (let_in (var "f") ~rhs:lam_f
+                  ~in_:(app (variable (var "f") (function_ty int_ty int_ty)) (int 5)))))
+  in
+  test_and_print "mixed let_in, let_mut_in, nested lambdas referencing overshadow" expr;
+  [%expect {|
+    --- mixed let_in, let_mut_in, nested lambdas referencing overshadow ---
+    Node: Let_in
+      luv = {f, g, ignore1, ignore_g, n, outer, x, z} nuv = {}
+      let_var=outer
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_mut_in
+        luv = {f, g, ignore1, ignore_g, n, outer, x, z} nuv = {}
+        let_var=x
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Let_in
+          luv = {f, g, ignore1, ignore_g, n, outer, x, z} nuv = {ignore1}
+          let_var=ignore1
+          rhs:
+          Node: Assign
+            luv = {} nuv = {}
+            let_var=x
+            value:
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Deref
+                luv = {} nuv = {}
+                mut_var=x
+              Node: Variable
+                luv = {} nuv = {}
+                var=outer
+          in_:
+          Node: Let_in
+            luv = {f, g, ignore_g, n, outer, x, z} nuv = {}
+            let_var=f
+            rhs:
+            Node: Lambda
+              luv = {g, ignore_g, n, outer, x, z} nuv = {}
+              lam_var=n
+              body:
+              Node: Let_in
+                luv = {g, ignore_g, n, outer, x, z} nuv = {}
+                let_var=g
+                rhs:
+                Node: Lambda
+                  luv = {ignore_g, x, z} nuv = {}
+                  lam_var=z
+                  body:
+                  Node: Let_in
+                    luv = {ignore_g, x, z} nuv = {ignore_g}
+                    let_var=ignore_g
+                    rhs:
+                    Node: Assign
+                      luv = {z} nuv = {}
+                      let_var=x
+                      value:
+                      Node: Prim
+                        luv = {z} nuv = {}
+                        args:
+                        Node: Deref
+                          luv = {} nuv = {}
+                          mut_var=x
+                        Node: Variable
+                          luv = {z} nuv = {}
+                          var=z
+                    in_:
+                    Node: Deref
+                      luv = {x} nuv = {}
+                      mut_var=x
+                in_:
+                Node: App
+                  luv = {g, n, outer} nuv = {}
+                  abs:
+                  Node: Variable
+                    luv = {g} nuv = {}
+                    var=g
+                  arg:
+                  Node: Prim
+                    luv = {n, outer} nuv = {}
+                    args:
+                    Node: Variable
+                      luv = {n} nuv = {}
+                      var=n
+                    Node: Variable
+                      luv = {outer} nuv = {}
+                      var=outer
+            in_:
+            Node: App
+              luv = {f} nuv = {}
+              abs:
+              Node: Variable
+                luv = {f} nuv = {}
+                var=f
+              arg:
+              Node: Const
+                luv = {} nuv = {}
+
+    { PUSH int 10 ;
+      PUSH int 0 ;
+      DUP 2 ;
+      DUP 2 ;
+      ADD ;
+      DUG 1 ;
+      DIG 0 ;
+      DROP ;
+      UNIT ;
+      DROP ;
+      LAMBDA
+        (pair int (pair int int))
+        int
+        { UNPAIR 3 ;
+          LAMBDA
+            (pair int int)
+            int
+            { UNPAIR ; SWAP ; DUP 2 ; ADD ; DUG 1 ; DIG 0 ; DROP ; UNIT ; DROP } ;
+          DIG 2 ;
+          APPLY ;
+          SWAP ;
+          DIG 2 ;
+          ADD ;
+          SWAP ;
+          SWAP ;
+          EXEC } ;
+      DIG 2 ;
+      APPLY ;
+      SWAP ;
+      APPLY ;
+      PUSH int 5 ;
+      SWAP ;
+      SWAP ;
+      EXEC }
+
+    Optimised:
+    { PUSH int 10 ;
+      PUSH int 0 ;
+      DUP 2 ;
+      ADD ;
+      LAMBDA
+        (pair int (pair int int))
+        int
+        { UNPAIR 3 ;
+          LAMBDA (pair int int) int { UNPAIR ; ADD } ;
+          DIG 2 ;
+          APPLY ;
+          SWAP ;
+          DIG 2 ;
+          ADD ;
+          EXEC } ;
+      DIG 2 ;
+      APPLY ;
+      SWAP ;
+      APPLY ;
+      PUSH int 5 ;
+      EXEC } |}]
+
+let%expect_test "test_const" =
+  let expr = int 42 in
+  test_and_print "test_const" expr;
+  [%expect {|
+    --- test_const ---
+    Node: Const
+      luv = {} nuv = {}
+
+    { PUSH int 42 }
+
+    Optimised:
+    { PUSH int 42 } |}]
+
+let%expect_test "test_prim_add" =
+  let lhs =
+    let_in (var "x") ~rhs:(int 10)
+      ~in_:(variable (var "x") int_ty)
+  in
+  let rhs = variable (var "y") int_ty in
+  let expr = add lhs rhs in
+  test_and_print "test_prim_add" expr;
+  [%expect {|
+    --- test_prim_add ---
+    Node: Prim
+      luv = {x, y} nuv = {}
+      args:
+      Node: Let_in
+        luv = {x} nuv = {}
+        let_var=x
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Variable
+          luv = {x} nuv = {}
+          var=x
+      Node: Variable
+        luv = {y} nuv = {}
+        var=y
+
+    { NEVER }
+
+    Optimised:
+    { NEVER } |}]
+
+let%expect_test "test_let_mut_in" =
+  let expr =
+    let_mut_in (mut_var "m") ~rhs:(int 100)
+      ~in_:(
+        let_in (var "m") ~rhs:(int 999)
+          ~in_:(assign (mut_var "m") (int 1))
+      )
+  in
+  test_and_print "test_let_mut_in" expr;
+  [%expect {|
+    --- test_let_mut_in ---
+    Node: Let_mut_in
+      luv = {m} nuv = {m}
+      let_var=m
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {m} nuv = {m}
+        let_var=m
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Assign
+          luv = {m} nuv = {m}
+          let_var=m
+          value:
+          Node: Const
+            luv = {} nuv = {}
+
+    { PUSH int 100 ; DROP ; PUSH int 999 ; DROP ; PUSH int 1 ; DROP ; UNIT }
+
+    Optimised:
+    { UNIT } |}]
+
+let%expect_test "let_mut_in basic multiple assignment" =
+  let mutM = mut_var "varM" in
+  let assign1 =
+    assign mutM (add (deref mutM int_ty) (int 1))
+  in
+  let assign2 =
+    assign mutM (add (deref mutM int_ty) (variable (var "varX") int_ty))
+  in
+  let expr =
+    let_mut_in mutM ~rhs:(int 0)
+      ~in_:
+        (let_in (var "temp1") ~rhs:assign1
+          ~in_:
+            (let_in (var "temp2") ~rhs:assign2
+              ~in_:(deref mutM int_ty)))
+  in
+  test_and_print "let_mut_in basic multiple assignment" expr;
+  [%expect {|
+    --- let_mut_in basic multiple assignment ---
+    Node: Let_mut_in
+      luv = {temp1, temp2, varM, varX} nuv = {}
+      let_var=varM
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {temp1, temp2, varM, varX} nuv = {temp1}
+        let_var=temp1
+        rhs:
+        Node: Assign
+          luv = {} nuv = {}
+          let_var=varM
+          value:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Deref
+              luv = {} nuv = {}
+              mut_var=varM
+            Node: Const
+              luv = {} nuv = {}
+        in_:
+        Node: Let_in
+          luv = {temp2, varM, varX} nuv = {temp2}
+          let_var=temp2
+          rhs:
+          Node: Assign
+            luv = {varX} nuv = {}
+            let_var=varM
+            value:
+            Node: Prim
+              luv = {varX} nuv = {}
+              args:
+              Node: Deref
+                luv = {} nuv = {}
+                mut_var=varM
+              Node: Variable
+                luv = {varX} nuv = {}
+                var=varX
+          in_:
+          Node: Deref
+            luv = {varM} nuv = {}
+            mut_var=varM
+
+    { PUSH int 0 ;
+      PUSH int 1 ;
+      DUP 2 ;
+      ADD ;
+      DUG 1 ;
+      DIG 0 ;
+      DROP ;
+      UNIT ;
+      DROP ;
+      NEVER }
+
+    Optimised:
+    { PUSH int 1 ; NEVER } |}]
+
+let%expect_test "test_deref" =
+  let expr =
+    let_mut_in (mut_var "x") ~rhs:(int 7)
+      ~in_:(let_in (var "x") ~rhs:(int 100)
+        ~in_:(deref (mut_var "x") int_ty))
+  in
+  test_and_print "test_deref" expr;
+  [%expect {|
+    --- test_deref ---
+    Node: Let_mut_in
+      luv = {x} nuv = {}
+      let_var=x
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {x} nuv = {}
+        let_var=x
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Deref
+          luv = {x} nuv = {}
+          mut_var=x
+
+    { PUSH int 7 ; PUSH int 100 ; SWAP ; DROP }
+
+    Optimised:
+    { PUSH int 100 } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 10. ASSIGN referencing overshadow var + unused var                   *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_assign" =
+  let expr =
+    let_mut_in (mut_var "m") ~rhs:(int 0)
+      ~in_:(assign (mut_var "m") (add (variable (var "unused") int_ty) (deref (mut_var "m") int_ty)))
+  in
+  test_and_print "test_assign" expr;
+  [%expect {|
+    --- test_assign ---
+    Node: Let_mut_in
+      luv = {m, unused} nuv = {}
+      let_var=m
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Assign
+        luv = {m, unused} nuv = {}
+        let_var=m
+        value:
+        Node: Prim
+          luv = {m, unused} nuv = {}
+          args:
+          Node: Variable
+            luv = {unused} nuv = {}
+            var=unused
+          Node: Deref
+            luv = {m} nuv = {}
+            mut_var=m
+
+    { PUSH int 0 ; NEVER }
+
+    Optimised:
+    { PUSH int 0 ; NEVER } |}]
+
+let%expect_test "nested assigns inside assigns" =
+  let mut_x = mut_var "x" in
+  let nested_assign =
+    let_mut_in (mut_var "x") ~rhs:(int 999)
+      ~in_:(assign (mut_var "x") (add (deref (mut_var "x") int_ty) (int 1)))
+  in
+  let first_assign =
+    assign mut_x (let_in (var "ignore") ~rhs:nested_assign ~in_:(deref (mut_var "x") int_ty))
+  in
+  let second_assign =
+    assign mut_x (add (deref mut_x int_ty) (int 5))
+  in
+  let final_expr =
+    let_mut_in mut_x ~rhs:(int 0)
+      ~in_:
+        (let_in (var "ignore1") ~rhs:first_assign
+          ~in_:
+            (let_in (var "ignore2") ~rhs:second_assign
+              ~in_:(deref mut_x int_ty)))
+  in
+  test_and_print "nested assigns inside assigns" final_expr;
+  [%expect {|
+    --- nested assigns inside assigns ---
+    Node: Let_mut_in
+      luv = {ignore, ignore1, ignore2, x} nuv = {}
+      let_var=x
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {ignore, ignore1, ignore2, x} nuv = {ignore1}
+        let_var=ignore1
+        rhs:
+        Node: Assign
+          luv = {ignore, x} nuv = {}
+          let_var=x
+          value:
+          Node: Let_in
+            luv = {ignore, x} nuv = {ignore}
+            let_var=ignore
+            rhs:
+            Node: Let_mut_in
+              luv = {x} nuv = {}
+              let_var=x
+              rhs:
+              Node: Const
+                luv = {} nuv = {}
+              in_:
+              Node: Assign
+                luv = {x} nuv = {}
+                let_var=x
+                value:
+                Node: Prim
+                  luv = {x} nuv = {}
+                  args:
+                  Node: Deref
+                    luv = {x} nuv = {}
+                    mut_var=x
+                  Node: Const
+                    luv = {} nuv = {}
+            in_:
+            Node: Deref
+              luv = {} nuv = {}
+              mut_var=x
+        in_:
+        Node: Let_in
+          luv = {ignore2, x} nuv = {ignore2}
+          let_var=ignore2
+          rhs:
+          Node: Assign
+            luv = {} nuv = {}
+            let_var=x
+            value:
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Deref
+                luv = {} nuv = {}
+                mut_var=x
+              Node: Const
+                luv = {} nuv = {}
+          in_:
+          Node: Deref
+            luv = {x} nuv = {}
+            mut_var=x
+
+    { PUSH int 0 ;
+      PUSH int 999 ;
+      PUSH int 1 ;
+      SWAP ;
+      ADD ;
+      SWAP ;
+      DROP ;
+      DROP ;
+      UNIT ;
+      DROP ;
+      NEVER }
+
+    Optimised:
+    { NEVER } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 11. IF_BOOL referencing distinct free vars in branches               *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_if_bool" =
+  let cond = lt (variable (var "c") int_ty) (int 10) in
+  let then_ = variable (var "x") int_ty in
+  let else_ = variable (var "y") int_ty in
+  let expr = if_bool cond ~then_ ~else_ in
+  test_and_print "test_if_bool" expr;
+  [%expect {|
+    --- test_if_bool ---
+    Node: If_bool
+      luv = {c, x, y} nuv = {}
+      condition:
+      Node: Prim
+        luv = {c} nuv = {}
+        args:
+        Node: Prim
+          luv = {c} nuv = {}
+          args:
+          Node: Variable
+            luv = {c} nuv = {}
+            var=c
+          Node: Const
+            luv = {} nuv = {}
+      if_true:
+      Node: Variable
+        luv = {x} nuv = {y}
+        var=x
+      if_false:
+      Node: Variable
+        luv = {y} nuv = {x}
+        var=y
+
+    { PUSH int 10 ; NEVER }
+
+    Optimised:
+    { PUSH int 10 ; NEVER } |}]
+
+let%expect_test "if_bool distinct var usage, no overshadow" =
+  (*
+    if eq(condVar, 0)
+      then thenVar + 100
+      else elseVar + 200
+  *)
+  let condition = eq (variable (var "condVar") int_ty) (int 0) in
+  let then_ = add (variable (var "thenVar") int_ty) (int 100) in
+  let else_ = add (variable (var "elseVar") int_ty) (int 200) in
+  let expr = if_bool condition ~then_ ~else_ in
+  test_and_print "if_bool distinct var usage, no overshadow" expr;
+  [%expect {|
+    --- if_bool distinct var usage, no overshadow ---
+    Node: If_bool
+      luv = {condVar, elseVar, thenVar} nuv = {}
+      condition:
+      Node: Prim
+        luv = {condVar} nuv = {}
+        args:
+        Node: Prim
+          luv = {condVar} nuv = {}
+          args:
+          Node: Variable
+            luv = {condVar} nuv = {}
+            var=condVar
+          Node: Const
+            luv = {} nuv = {}
+      if_true:
+      Node: Prim
+        luv = {thenVar} nuv = {elseVar}
+        args:
+        Node: Variable
+          luv = {thenVar} nuv = {}
+          var=thenVar
+        Node: Const
+          luv = {} nuv = {}
+      if_false:
+      Node: Prim
+        luv = {elseVar} nuv = {thenVar}
+        args:
+        Node: Variable
+          luv = {elseVar} nuv = {}
+          var=elseVar
+        Node: Const
+          luv = {} nuv = {}
+
+    { PUSH int 0 ; NEVER }
+
+    Optimised:
+    { PUSH int 0 ; NEVER } |}]
+
+let%expect_test "complex nested if_bool overshadow" =
+  let condition1 = lt (variable (var "x") int_ty) (int 10) in
+  let then_branch =
+    let condition2 = eq (variable (var "x") int_ty) (int 5) in
+    let then_let =
+      let_in (var "x") ~rhs:(int 999)
+        ~in_:(variable (var "x") int_ty)
+    in
+    let else_mut =
+      let_mut_in (mut_var "x") ~rhs:(int 2)
+        ~in_:(assign (mut_var "x") (add (deref (mut_var "x") int_ty) (int 100)))
+    in
+    if_bool condition2 ~then_:then_let ~else_:else_mut
+  in
+  let else_branch = variable (var "x") int_ty in
+  let expr =
+    let_in (var "x") ~rhs:(int 1)
+      ~in_:(if_bool condition1 ~then_:then_branch ~else_:else_branch)
+  in
+  test_and_print "complex nested if_bool overshadow" expr;
+  [%expect {|
+    --- complex nested if_bool overshadow ---
+    Node: Let_in
+      luv = {x} nuv = {}
+      let_var=x
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: If_bool
+        luv = {x} nuv = {}
+        condition:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Variable
+              luv = {} nuv = {}
+              var=x
+            Node: Const
+              luv = {} nuv = {}
+        if_true:
+        Node: If_bool
+          luv = {x} nuv = {}
+          condition:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Variable
+                luv = {} nuv = {}
+                var=x
+              Node: Const
+                luv = {} nuv = {}
+          if_true:
+          Node: Let_in
+            luv = {x} nuv = {}
+            let_var=x
+            rhs:
+            Node: Const
+              luv = {} nuv = {}
+            in_:
+            Node: Variable
+              luv = {x} nuv = {}
+              var=x
+          if_false:
+          Node: Let_mut_in
+            luv = {x} nuv = {}
+            let_var=x
+            rhs:
+            Node: Const
+              luv = {} nuv = {}
+            in_:
+            Node: Assign
+              luv = {x} nuv = {}
+              let_var=x
+              value:
+              Node: Prim
+                luv = {x} nuv = {}
+                args:
+                Node: Deref
+                  luv = {x} nuv = {}
+                  mut_var=x
+                Node: Const
+                  luv = {} nuv = {}
+        if_false:
+        Node: Variable
+          luv = {x} nuv = {}
+          var=x
+
+    { PUSH int 1 ;
+      PUSH int 10 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      IF { PUSH int 5 ;
+           DUP 2 ;
+           COMPARE ;
+           EQ ;
+           IF { PUSH int 999 ; SWAP ; DROP }
+              { PUSH int 2 ; PUSH int 100 ; SWAP ; ADD ; SWAP ; DROP ; DROP ; UNIT } }
+         {} }
+
+    Optimised:
+    { PUSH int 1 ;
+      PUSH int 10 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      IF { PUSH int 5 ; COMPARE ; EQ ; IF { PUSH int 999 } { UNIT } } {} } |}]
+
+let%expect_test "complicated if_bool + while + deref + overshadow" =
+  (*
+    let mut counter = 0 in
+    while (counter < 3) do
+      if eq(counter,1)
+        then let x = counter in x
+        else counter := counter + 10
+    done
+    let x=counter in x+1
+  *)
+  let mut_counter = mut_var "counter" in
+  let body =
+    if_bool
+      (eq (deref mut_counter int_ty) (int 1))
+      ~then_:(let_in (var "x") ~rhs:(deref mut_counter int_ty)
+                ~in_:(variable (var "x") int_ty))
+      ~else_:(assign mut_counter (add (deref mut_counter int_ty) (int 10)))
+  in
+  let while_expr =
+    while_ (lt (deref mut_counter int_ty) (int 3)) ~body
+  in
+  let after_while =
+    let_in (var "x") ~rhs:(deref mut_counter int_ty)
+      ~in_:(add (variable (var "x") int_ty) (int 1))
+  in
+  let expr =
+    let_mut_in mut_counter ~rhs:(int 0)
+      ~in_:
+        (let_in (var "ignore_wh") ~rhs:while_expr
+          ~in_:after_while)
+  in
+  test_and_print "complicated if_bool + while + deref + overshadow" expr;
+  [%expect {|
+    --- complicated if_bool + while + deref + overshadow ---
+    Node: Let_mut_in
+      luv = {counter, ignore_wh, x} nuv = {}
+      let_var=counter
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {counter, ignore_wh, x} nuv = {ignore_wh}
+        let_var=ignore_wh
+        rhs:
+        Node: While
+          luv = {x} nuv = {}
+          cond:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Deref
+                luv = {} nuv = {}
+                mut_var=counter
+              Node: Const
+                luv = {} nuv = {}
+          body:
+          Node: If_bool
+            luv = {x} nuv = {}
+            condition:
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Prim
+                luv = {} nuv = {}
+                args:
+                Node: Deref
+                  luv = {} nuv = {}
+                  mut_var=counter
+                Node: Const
+                  luv = {} nuv = {}
+            if_true:
+            Node: Let_in
+              luv = {x} nuv = {}
+              let_var=x
+              rhs:
+              Node: Deref
+                luv = {} nuv = {}
+                mut_var=counter
+              in_:
+              Node: Variable
+                luv = {x} nuv = {}
+                var=x
+            if_false:
+            Node: Assign
+              luv = {} nuv = {x}
+              let_var=counter
+              value:
+              Node: Prim
+                luv = {} nuv = {}
+                args:
+                Node: Deref
+                  luv = {} nuv = {}
+                  mut_var=counter
+                Node: Const
+                  luv = {} nuv = {}
+        in_:
+        Node: Let_in
+          luv = {counter, x} nuv = {}
+          let_var=x
+          rhs:
+          Node: Deref
+            luv = {counter} nuv = {}
+            mut_var=counter
+          in_:
+          Node: Prim
+            luv = {x} nuv = {}
+            args:
+            Node: Variable
+              luv = {x} nuv = {}
+              var=x
+            Node: Const
+              luv = {} nuv = {}
+
+    { PUSH int 0 ;
+      PUSH int 3 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { PUSH int 1 ;
+             DUP 2 ;
+             COMPARE ;
+             EQ ;
+             IF { DUP 1 } { PUSH int 10 ; DUP 2 ; ADD ; DUG 1 ; DIG 0 ; DROP ; UNIT } ;
+             DROP ;
+             PUSH int 3 ;
+             DUP 2 ;
+             COMPARE ;
+             LT } ;
+      UNIT ;
+      DROP ;
+      PUSH int 1 ;
+      SWAP ;
+      ADD }
+
+    Optimised:
+    { PUSH int 0 ;
+      PUSH int 3 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { PUSH int 1 ;
+             DUP 2 ;
+             COMPARE ;
+             EQ ;
+             IF {} { PUSH int 10 ; ADD } ;
+             PUSH int 3 ;
+             DUP 2 ;
+             COMPARE ;
+             LT } ;
+      PUSH int 1 ;
+      ADD } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 12. IF_NONE overshadow in none branch, overshadow in some           *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_if_none" =
+  let subject = variable (var "maybeVal") (option_ty int_ty) in
+  let none_ =
+    let_in (var "maybeVal") ~rhs:(int 999)
+      ~in_:(int 1)
+  in
+  let some_body =
+    add (variable (var "outer") int_ty) (variable (var "v") int_ty)
+  in
+  let expr =
+    let_in (var "outer") ~rhs:(int 100)
+      ~in_:(if_none subject ~none:none_
+        ~some:{ lam_var=(var "v", int_ty); body=some_body })
+  in
+  test_and_print "test_if_none" expr;
+  [%expect {|
+    --- test_if_none ---
+    Node: Let_in
+      luv = {maybeVal, outer, v} nuv = {}
+      let_var=outer
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: If_none
+        luv = {maybeVal, outer, v} nuv = {}
+        subject:
+        Node: Variable
+          luv = {} nuv = {}
+          var=maybeVal
+        if_none:
+        Node: Let_in
+          luv = {maybeVal} nuv = {outer, v}
+          let_var=maybeVal
+          rhs:
+          Node: Const
+            luv = {} nuv = {}
+          in_:
+          Node: Const
+            luv = {} nuv = {}
+        if_some lam_var=v
+        if_some body:
+        Node: Prim
+          luv = {outer, v} nuv = {maybeVal}
+          args:
+          Node: Variable
+            luv = {outer} nuv = {}
+            var=outer
+          Node: Variable
+            luv = {v} nuv = {}
+            var=v
+
+    { PUSH int 100 ; NEVER }
+
+    Optimised:
+    { PUSH int 100 ; NEVER } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 13. IF_CONS overshadow lam_var1 lam_var2                             *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_if_cons" =
+  let lst = variable (var "lst") (list_ty nat_ty) in
+  let empty_expr = int 999 in
+  let nonempty_body =
+    add (variable (var "hd") nat_ty) (variable (var "hd2") nat_ty)
+  in
+  let expr =
+    if_cons lst
+      ~empty:empty_expr
+      ~nonempty:{
+        lam_var1=(var "hd",nat_ty);
+        lam_var2=(var "hd2",list_ty nat_ty);
+        body=nonempty_body
+      }
+  in
+  test_and_print "test_if_cons" expr;
+  [%expect {|
+    --- test_if_cons ---
+    Node: If_cons
+      luv = {hd, hd2, lst} nuv = {}
+      subject:
+      Node: Variable
+        luv = {lst} nuv = {}
+        var=lst
+      if_empty:
+      Node: Const
+        luv = {} nuv = {hd, hd2}
+      if_nonempty lam_var1=hd lam_var2=hd2
+      if_nonempty body:
+      Node: Prim
+        luv = {hd, hd2} nuv = {}
+        args:
+        Node: Variable
+          luv = {hd} nuv = {}
+          var=hd
+        Node: Variable
+          luv = {hd2} nuv = {}
+          var=hd2
+
+    { NEVER }
+
+    Optimised:
+    { NEVER } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 14. IF_LEFT overshadow lam_var in left or right                      *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_if_left" =
+  let or_val = variable (var "s") (or_ty (mk_row [Row.Leaf(None,int_ty); Row.Leaf(None,nat_ty)])) in
+  let left_body =
+    let_in (var "s") ~rhs:(int 999)
+      ~in_:(variable (var "l") int_ty)
+  in
+  let right_body =
+    add (variable (var "r") nat_ty) (int 1)
+  in
+  let expr =
+    if_left or_val
+      ~left:{ lam_var=(var "l", int_ty); body=left_body }
+      ~right:{ lam_var=(var "r", nat_ty); body=right_body }
+  in
+  test_and_print "test_if_left" expr;
+  [%expect {|
+    --- test_if_left ---
+    Node: If_left
+      luv = {l, r, s} nuv = {}
+      subject:
+      Node: Variable
+        luv = {} nuv = {}
+        var=s
+      if_left lam_var=l
+      Node: Let_in
+        luv = {l, s} nuv = {r}
+        let_var=s
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Variable
+          luv = {l} nuv = {}
+          var=l
+      if_right lam_var=r
+      Node: Prim
+        luv = {r} nuv = {l, s}
+        args:
+        Node: Variable
+          luv = {r} nuv = {}
+          var=r
+        Node: Const
+          luv = {} nuv = {}
+
+    { NEVER }
+
+    Optimised:
+    { NEVER } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 15. WHILE referencing overshadow var + nested let_in                *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_while" =
+  let body_expr =
+    let_in (var "q") ~rhs:(int 123)
+      ~in_:(assign (mut_var "m") (variable (var "q") int_ty))
+  in
+  let expr =
+    let_mut_in (mut_var "m") ~rhs:(int 0)
+      ~in_:(while_
+              (lt (deref (mut_var "m") int_ty) (int 5))
+              ~body:body_expr)
+  in
+  test_and_print "test_while" expr;
+  [%expect {|
+    --- test_while ---
+    Node: Let_mut_in
+      luv = {m, q} nuv = {}
+      let_var=m
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: While
+        luv = {m, q} nuv = {}
+        cond:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Deref
+              luv = {} nuv = {}
+              mut_var=m
+            Node: Const
+              luv = {} nuv = {}
+        body:
+        Node: Let_in
+          luv = {q} nuv = {}
+          let_var=q
+          rhs:
+          Node: Const
+            luv = {} nuv = {}
+          in_:
+          Node: Assign
+            luv = {q} nuv = {}
+            let_var=m
+            value:
+            Node: Variable
+              luv = {q} nuv = {}
+              var=q
+
+    { PUSH int 0 ;
+      PUSH int 5 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { PUSH int 123 ;
+             DUG 1 ;
+             DIG 0 ;
+             DROP ;
+             UNIT ;
+             DROP ;
+             PUSH int 5 ;
+             DUP 2 ;
+             COMPARE ;
+             LT } ;
+      UNIT ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH int 0 ;
+      PUSH int 5 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { DROP ; PUSH int 123 ; PUSH int 5 ; DUP 2 ; COMPARE ; LT } ;
+      DROP ;
+      UNIT } |}]
+
+let%expect_test "while referencing outside variables" =
+  (*
+    let mut i=0 in
+    while i < limit do
+      i := i + step
+    done
+    i
+  *)
+  let mutI = mut_var "i" in
+  let limitVar = variable (var "limit") int_ty in
+  let stepVar = variable (var "step") int_ty in
+  let body_expr =
+    assign mutI (add (deref mutI int_ty) stepVar)
+  in
+  let expr =
+    let_mut_in mutI ~rhs:(int 0)
+      ~in_:
+        (while_ (lt (deref mutI int_ty) limitVar) ~body:body_expr)
+  in
+  test_and_print "while referencing outside variables" expr;
+  [%expect {|
+    --- while referencing outside variables ---
+    Node: Let_mut_in
+      luv = {i, limit, step} nuv = {}
+      let_var=i
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: While
+        luv = {i, limit, step} nuv = {}
+        cond:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Deref
+              luv = {} nuv = {}
+              mut_var=i
+            Node: Variable
+              luv = {} nuv = {}
+              var=limit
+        body:
+        Node: Assign
+          luv = {} nuv = {}
+          let_var=i
+          value:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Deref
+              luv = {} nuv = {}
+              mut_var=i
+            Node: Variable
+              luv = {} nuv = {}
+              var=step
+
+    { PUSH int 0 ; NEVER }
+
+    Optimised:
+    { PUSH int 0 ; NEVER } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 16. WHILE_LEFT overshadow lam_var in body                            *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_while_left" =
+  let start_val = left (None, None, int_ty) (int 10) in
+  let expr = while_left start_val ~body:{
+    lam_var=(var "flag", int_ty);
+    body=(
+      let_in (var "flag") ~rhs:(int 999)
+        ~in_:(right (None,None,int_ty) (int 123))
+    )
+  } in
+  test_and_print "test_while_left" expr;
+  [%expect {|
+    --- test_while_left ---
+    Node: While_left
+      luv = {flag} nuv = {}
+      cond:
+      Node: Prim
+        luv = {} nuv = {}
+        args:
+        Node: Const
+          luv = {} nuv = {}
+      lam_var=flag
+      body:
+      Node: Let_in
+        luv = {flag} nuv = {flag}
+        let_var=flag
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Const
+            luv = {} nuv = {}
+
+    { PUSH int 10 ;
+      LEFT int ;
+      LEFT int ;
+      LOOP_LEFT { DROP ; PUSH int 999 ; DROP ; PUSH int 123 ; RIGHT int } }
+
+    Optimised:
+    { PUSH int 10 ;
+      LEFT int ;
+      LEFT int ;
+      LOOP_LEFT { DROP ; PUSH int 123 ; RIGHT int } } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 17. FOR referencing index overshadow body var + outer var           *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_for" =
+  let idx = mut_var "i" in
+  let body_expr =
+    let_in (var "i") ~rhs:(int 999)
+      ~in_:(assign (mut_var "acc") (variable (var "i") int_ty))
+  in
+  let expr =
+    let_mut_in (mut_var "acc") ~rhs:(int 0)
+      ~in_:(for_
+              idx
+              ~init:(int 0)
+              ~cond:(lt (deref idx int_ty) (int 5))
+              ~update:(assign idx (add (deref idx int_ty) (int 1)))
+              ~body:body_expr)
+  in
+  test_and_print "test_for" expr;
+  [%expect {|
+    --- test_for ---
+    Node: Let_mut_in
+      luv = {acc, i} nuv = {acc}
+      let_var=acc
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: For
+        luv = {acc, i} nuv = {}
+        index=i
+        init:
+        Node: Const
+          luv = {} nuv = {}
+        cond:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Deref
+              luv = {} nuv = {}
+              mut_var=i
+            Node: Const
+              luv = {} nuv = {}
+        update:
+        Node: Assign
+          luv = {} nuv = {}
+          let_var=i
+          value:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Deref
+              luv = {} nuv = {}
+              mut_var=i
+            Node: Const
+              luv = {} nuv = {}
+        body:
+        Node: Let_in
+          luv = {i} nuv = {}
+          let_var=i
+          rhs:
+          Node: Const
+            luv = {} nuv = {}
+          in_:
+          Node: Assign
+            luv = {i} nuv = {acc}
+            let_var=acc
+            value:
+            Node: Variable
+              luv = {i} nuv = {}
+              var=i
+
+    { PUSH int 0 ;
+      DROP ;
+      PUSH int 0 ;
+      PUSH int 5 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { PUSH int 999 ; DROP ; UNIT ; SWAP ; DROP ; DROP ; PUSH int 1 ; NEVER } ;
+      DROP ;
+      UNIT }
+
+    Optimised:
+    { PUSH int 0 ;
+      PUSH int 5 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { DROP ; PUSH int 1 ; NEVER } ;
+      DROP ;
+      UNIT } |}]
+
+let%expect_test "for_ partial apply overshadow in body" =
+  (*
+    let mut i=0 in
+    let f = lambda (p:(int,int)) -> fst(p) + snd(p) + i in
+    for i= i+1 until i<4 do
+      let partial = apply(2,f) in
+      partial(3)
+    done
+  *)
+  let idx = mut_var "i" in
+  let pair_ty = Ast_builder.With_dummy.mk_tuple_ty [int_ty; int_ty] in
+  let lam_f =
+    lambda (var "p", pair_ty)
+      ~body:(
+        add
+          (car (variable (var "p") pair_ty))
+          (add (cdr (variable (var "p") pair_ty)) (deref idx int_ty))
+      )
+  in
+  let body_expr =
+    let_in (var "partial") ~rhs:(apply (int 2) lam_f)
+      ~in_:(app (variable (var "partial") (function_ty int_ty int_ty)) (int 3))
+  in
+  let expr =
+    let_mut_in idx ~rhs:(int 0)
+      ~in_:
+        (let_in (var "f") ~rhs:lam_f
+          ~in_:
+            (for_ idx
+              ~init:(deref idx int_ty)
+              ~cond:(lt (deref idx int_ty) (int 4))
+              ~update:(assign idx (add (deref idx int_ty) (int 1)))
+              ~body:body_expr))
+  in
+  test_and_print "for_ partial apply overshadow in body" expr;
+  [%expect {|
+    --- for_ partial apply overshadow in body ---
+    Node: Let_mut_in
+      luv = {f, i, p, partial} nuv = {}
+      let_var=i
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Let_in
+        luv = {f, i, p, partial} nuv = {f}
+        let_var=f
+        rhs:
+        Node: Lambda
+          luv = {p} nuv = {}
+          lam_var=p
+          body:
+          Node: Prim
+            luv = {p} nuv = {}
+            args:
+            Node: Prim
+              luv = {p} nuv = {}
+              args:
+              Node: Variable
+                luv = {p} nuv = {}
+                var=p
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Prim
+                luv = {} nuv = {}
+                args:
+                Node: Variable
+                  luv = {} nuv = {}
+                  var=p
+              Node: Deref
+                luv = {} nuv = {}
+                mut_var=i
+        in_:
+        Node: For
+          luv = {i, p, partial} nuv = {}
+          index=i
+          init:
+          Node: Deref
+            luv = {} nuv = {}
+            mut_var=i
+          cond:
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Deref
+                luv = {} nuv = {}
+                mut_var=i
+              Node: Const
+                luv = {} nuv = {}
+          update:
+          Node: Assign
+            luv = {} nuv = {}
+            let_var=i
+            value:
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Deref
+                luv = {} nuv = {}
+                mut_var=i
+              Node: Const
+                luv = {} nuv = {}
+          body:
+          Node: Let_in
+            luv = {p, partial} nuv = {}
+            let_var=partial
+            rhs:
+            Node: Prim
+              luv = {p} nuv = {}
+              args:
+              Node: Const
+                luv = {} nuv = {}
+              Node: Lambda
+                luv = {p} nuv = {}
+                lam_var=p
+                body:
+                Node: Prim
+                  luv = {p} nuv = {}
+                  args:
+                  Node: Prim
+                    luv = {p} nuv = {}
+                    args:
+                    Node: Variable
+                      luv = {p} nuv = {}
+                      var=p
+                  Node: Prim
+                    luv = {} nuv = {}
+                    args:
+                    Node: Prim
+                      luv = {} nuv = {}
+                      args:
+                      Node: Variable
+                        luv = {} nuv = {}
+                        var=p
+                    Node: Deref
+                      luv = {} nuv = {}
+                      mut_var=i
+            in_:
+            Node: App
+              luv = {partial} nuv = {}
+              abs:
+              Node: Variable
+                luv = {partial} nuv = {}
+                var=partial
+              arg:
+              Node: Const
+                luv = {} nuv = {}
+
+    { PUSH int 0 ;
+      LAMBDA
+        (pair int (pair int int))
+        int
+        { UNPAIR ; DUP 1 ; DUP 3 ; CDR ; ADD ; DIG 2 ; CAR ; ADD ; SWAP ; DROP } ;
+      DUP 2 ;
+      APPLY ;
+      DROP ;
+      DUP 1 ;
+      PUSH int 4 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { LAMBDA
+               (pair int (pair int int))
+               int
+               { UNPAIR ; DUP 1 ; DUP 3 ; CDR ; ADD ; DIG 2 ; CAR ; ADD ; SWAP ; DROP } ;
+             DUP 2 ;
+             APPLY ;
+             PUSH int 2 ;
+             APPLY ;
+             PUSH int 3 ;
+             SWAP ;
+             SWAP ;
+             EXEC ;
+             DROP ;
+             PUSH int 1 ;
+             DUP 2 ;
+             ADD ;
+             DUG 1 ;
+             DIG 0 ;
+             DROP ;
+             UNIT ;
+             DROP ;
+             PUSH int 4 ;
+             DUP 2 ;
+             COMPARE ;
+             LT } ;
+      DROP ;
+      UNIT ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH int 0 ;
+      PUSH int 4 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { LAMBDA
+               (pair int (pair int int))
+               int
+               { UNPAIR ; DUP 2 ; CDR ; ADD ; SWAP ; CAR ; ADD } ;
+             DUP 2 ;
+             APPLY ;
+             PUSH int 2 ;
+             APPLY ;
+             PUSH int 3 ;
+             EXEC ;
+             DROP ;
+             PUSH int 1 ;
+             ADD ;
+             PUSH int 4 ;
+             DUP 2 ;
+             COMPARE ;
+             LT } ;
+      DROP ;
+      UNIT } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 18. FOR_EACH overshadow lam_var, referencing outer var              *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_for_each" =
+  let collection = cons (int 1) (cons (int 2) (nil int_ty)) in
+  let lam_body =
+    let_in (var "elem") ~rhs:(int 999)
+      ~in_:(add (variable (var "elem") int_ty) (variable (var "outer") int_ty))
+  in
+  let expr =
+    let_in (var "outer") ~rhs:(int 100)
+      ~in_:(for_each collection ~body:{ lam_var=(var "elem", int_ty); body=lam_body })
+  in
+  test_and_print "test_for_each" expr;
+  [%expect {|
+    --- test_for_each ---
+    Node: Let_in
+      luv = {elem, outer} nuv = {}
+      let_var=outer
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: For_each
+        luv = {elem, outer} nuv = {}
+        collection:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Const
+            luv = {} nuv = {}
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Const
+              luv = {} nuv = {}
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+        lam_var=elem
+        body:
+        Node: Let_in
+          luv = {elem} nuv = {}
+          let_var=elem
+          rhs:
+          Node: Const
+            luv = {} nuv = {}
+          in_:
+          Node: Prim
+            luv = {elem} nuv = {}
+            args:
+            Node: Variable
+              luv = {elem} nuv = {}
+              var=elem
+            Node: Variable
+              luv = {} nuv = {}
+              var=outer
+
+    { PUSH int 100 ;
+      NIL int ;
+      PUSH int 2 ;
+      CONS ;
+      PUSH int 1 ;
+      CONS ;
+      ITER { PUSH int 999 ; DUP 3 ; SWAP ; ADD ; SWAP ; DROP ; DROP } ;
+      UNIT ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH int 100 ;
+      PUSH (list int) { 1 ; 2 } ;
+      ITER { DROP ; PUSH int 999 ; DUP 2 ; ADD ; DROP } ;
+      DROP ;
+      UNIT } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 19. MAP overshadow lam_var, referencing outer var                   *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_map" =
+  let collection = cons (nat 1) (cons (nat 2) (nil nat_ty)) in
+  let lam_body =
+    let_in (var "x") ~rhs:(nat 999)
+      ~in_:(add (variable (var "x") nat_ty) (variable (var "outer") nat_ty))
+  in
+  let expr =
+    let_in (var "outer") ~rhs:(nat 10)
+      ~in_:(map collection ~map:{ lam_var=(var "x", nat_ty); body=lam_body })
+  in
+  test_and_print "test_map" expr;
+  [%expect {|
+    --- test_map ---
+    Node: Let_in
+      luv = {outer, x} nuv = {}
+      let_var=outer
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Map
+        luv = {outer, x} nuv = {}
+        collection:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Const
+            luv = {} nuv = {}
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Const
+              luv = {} nuv = {}
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+        lam_var=x
+        body:
+        Node: Let_in
+          luv = {x} nuv = {}
+          let_var=x
+          rhs:
+          Node: Const
+            luv = {} nuv = {}
+          in_:
+          Node: Prim
+            luv = {x} nuv = {}
+            args:
+            Node: Variable
+              luv = {x} nuv = {}
+              var=x
+            Node: Variable
+              luv = {} nuv = {}
+              var=outer
+
+    { PUSH nat 10 ;
+      NIL nat ;
+      PUSH nat 2 ;
+      CONS ;
+      PUSH nat 1 ;
+      CONS ;
+      MAP { PUSH nat 999 ; DUP 3 ; SWAP ; ADD ; SWAP ; DROP } ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH nat 10 ;
+      PUSH (list nat) { 1 ; 2 } ;
+      MAP { DROP ; PUSH nat 999 ; DUP 2 ; ADD } ;
+      SWAP ;
+      DROP } |}]
+
+let%expect_test "map overshadow partial usage" =
+  (*
+    let x=999 in
+    map [10,20] ( lam v-> (let x=v in x + 1) + x )
+  *)
+  let list_expr = cons (int 10) (cons (int 20) (nil int_ty)) in
+  let lam_body =
+    add
+      (let_in (var "x") ~rhs:(variable (var "v") int_ty)
+         ~in_:(add (variable (var "x") int_ty) (int 1)))
+      (variable (var "x") int_ty)
+  in
+  let expr =
+    let_in (var "x") ~rhs:(int 999)
+      ~in_:
+       (map list_expr ~map:{
+          lam_var=(var "v", int_ty);
+          body=lam_body
+        })
+  in
+  test_and_print "map overshadow partial usage" expr;
+  [%expect {|
+    --- map overshadow partial usage ---
+    Node: Let_in
+      luv = {v, x} nuv = {}
+      let_var=x
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Map
+        luv = {v, x} nuv = {}
+        collection:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Const
+            luv = {} nuv = {}
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Const
+              luv = {} nuv = {}
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+        lam_var=v
+        body:
+        Node: Prim
+          luv = {v, x} nuv = {}
+          args:
+          Node: Let_in
+            luv = {v, x} nuv = {}
+            let_var=x
+            rhs:
+            Node: Variable
+              luv = {v} nuv = {}
+              var=v
+            in_:
+            Node: Prim
+              luv = {x} nuv = {}
+              args:
+              Node: Variable
+                luv = {x} nuv = {}
+                var=x
+              Node: Const
+                luv = {} nuv = {}
+          Node: Variable
+            luv = {} nuv = {}
+            var=x
+
+    { PUSH int 999 ;
+      NIL int ;
+      PUSH int 20 ;
+      CONS ;
+      PUSH int 10 ;
+      CONS ;
+      MAP { DUP 2 ; SWAP ; PUSH int 1 ; SWAP ; ADD ; DIG 2 ; DROP ; ADD } ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH int 999 ;
+      PUSH (list int) { 10 ; 20 } ;
+      MAP { PUSH int 1 ; ADD ; ADD } ;
+      SWAP ;
+      DROP } |}]
+
+
+let%expect_test "map usage referencing outside var, multiple item usage" =
+  (*
+    let factor=3 in
+    map [10,20]  ( lam item -> item + item + factor )
+  *)
+  let list_expr = cons (int 10) (cons (int 20) (nil int_ty)) in
+  let lam_body =
+    add
+      (variable (var "item") int_ty)
+      (add (variable (var "item") int_ty) (variable (var "factor") int_ty))
+  in
+  let expr =
+    let_in (var "factor") ~rhs:(int 3)
+      ~in_:
+        (map list_expr
+          ~map:{ lam_var=(var "item", int_ty); body=lam_body })
+  in
+  test_and_print "map usage referencing outside var, multiple item usage" expr;
+  [%expect {|
+    --- map usage referencing outside var, multiple item usage ---
+    Node: Let_in
+      luv = {factor, item} nuv = {}
+      let_var=factor
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Map
+        luv = {factor, item} nuv = {}
+        collection:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Const
+            luv = {} nuv = {}
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Const
+              luv = {} nuv = {}
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+        lam_var=item
+        body:
+        Node: Prim
+          luv = {item} nuv = {}
+          args:
+          Node: Variable
+            luv = {item} nuv = {}
+            var=item
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Variable
+              luv = {} nuv = {}
+              var=item
+            Node: Variable
+              luv = {} nuv = {}
+              var=factor
+
+    { PUSH int 3 ;
+      NIL int ;
+      PUSH int 20 ;
+      CONS ;
+      PUSH int 10 ;
+      CONS ;
+      MAP { DUP 2 ; DUP 2 ; ADD ; SWAP ; ADD } ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH int 3 ;
+      PUSH (list int) { 10 ; 20 } ;
+      MAP { DUP 2 ; DUP 2 ; ADD ; ADD } ;
+      SWAP ;
+      DROP } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 20. FOLD_LEFT overshadow lam_var + referencing init                 *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_fold_left" =
+  let coll = cons (int 1) (cons (int 2) (nil int_ty)) in
+  let init_expr = int 0 in
+  let lam_body =
+    let_in (var "acc") ~rhs:(int 999)
+      ~in_:(add
+              (car (variable (var "acc") (mk_tuple_ty [int_ty; int_ty])))
+              (cdr (variable (var "acc") (mk_tuple_ty [int_ty; int_ty]))))
+  in
+  let expr =
+    fold_left coll ~init:init_expr
+      ~fold:{ lam_var=(var "acc", mk_tuple_ty [int_ty; int_ty]); body=lam_body }
+  in
+  test_and_print "test_fold_left" expr;
+  [%expect {|
+    --- test_fold_left ---
+    Node: Fold_left
+      luv = {acc} nuv = {}
+      collection:
+      Node: Prim
+        luv = {} nuv = {}
+        args:
+        Node: Const
+          luv = {} nuv = {}
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Const
+            luv = {} nuv = {}
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+      init:
+      Node: Const
+        luv = {} nuv = {}
+      lam_var=acc
+      body:
+      Node: Let_in
+        luv = {acc} nuv = {}
+        let_var=acc
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Prim
+          luv = {acc} nuv = {}
+          args:
+          Node: Prim
+            luv = {acc} nuv = {}
+            args:
+            Node: Variable
+              luv = {acc} nuv = {}
+              var=acc
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Variable
+              luv = {} nuv = {}
+              var=acc
+
+    { PUSH int 0 ;
+      NIL int ;
+      PUSH int 2 ;
+      CONS ;
+      PUSH int 1 ;
+      CONS ;
+      ITER { SWAP ;
+             PAIR ;
+             PUSH int 999 ;
+             DUP 1 ;
+             CDR ;
+             SWAP ;
+             CAR ;
+             ADD ;
+             SWAP ;
+             DROP } }
+
+    Optimised:
+    { PUSH int 0 ;
+      PUSH (list int) { 1 ; 2 } ;
+      ITER { DROP 2 ; PUSH int 999 ; UNPAIR ; ADD } } |}]
+
+let%expect_test "fold_left overshadow inside body" =
+  (*
+    let outside=7 in
+    fold_left [1,2,3] init=0
+      (acc,x)-> let x=acc+outside in x + x
+  *)
+  let coll = cons (int 1) (cons (int 2) (cons (int 3) (nil int_ty))) in
+  let fold_body =
+    let_in (var "x") ~rhs:(add (car (variable (var "acc") (mk_tuple_ty [int_ty; int_ty])))
+                            (variable (var "outside") int_ty))
+      ~in_:(add (variable (var "x") int_ty) (variable (var "x") int_ty))
+  in
+  let expr =
+    let_in (var "outside") ~rhs:(int 7)
+      ~in_:
+        (fold_left coll ~init:(int 0)
+          ~fold:{
+            lam_var=(var "acc", mk_tuple_ty [int_ty; int_ty]);
+            body=fold_body
+          })
+  in
+  test_and_print "fold_left overshadow inside body" expr;
+  [%expect {|
+    --- fold_left overshadow inside body ---
+    Node: Let_in
+      luv = {acc, outside, x} nuv = {}
+      let_var=outside
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Fold_left
+        luv = {acc, outside, x} nuv = {}
+        collection:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Const
+            luv = {} nuv = {}
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Const
+              luv = {} nuv = {}
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Const
+                luv = {} nuv = {}
+              Node: Prim
+                luv = {} nuv = {}
+                args:
+        init:
+        Node: Const
+          luv = {} nuv = {}
+        lam_var=acc
+        body:
+        Node: Let_in
+          luv = {acc, x} nuv = {}
+          let_var=x
+          rhs:
+          Node: Prim
+            luv = {acc} nuv = {}
+            args:
+            Node: Prim
+              luv = {acc} nuv = {}
+              args:
+              Node: Variable
+                luv = {acc} nuv = {}
+                var=acc
+            Node: Variable
+              luv = {} nuv = {}
+              var=outside
+          in_:
+          Node: Prim
+            luv = {x} nuv = {}
+            args:
+            Node: Variable
+              luv = {x} nuv = {}
+              var=x
+            Node: Variable
+              luv = {} nuv = {}
+              var=x
+
+    { PUSH int 7 ;
+      PUSH int 0 ;
+      NIL int ;
+      PUSH int 3 ;
+      CONS ;
+      PUSH int 2 ;
+      CONS ;
+      PUSH int 1 ;
+      CONS ;
+      ITER { SWAP ; PAIR ; DUP 2 ; SWAP ; CAR ; ADD ; DUP 1 ; SWAP ; ADD } ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH int 7 ;
+      PUSH int 0 ;
+      PUSH (list int) { 1 ; 2 ; 3 } ;
+      ITER { SWAP ; PAIR ; DUP 2 ; SWAP ; CAR ; ADD ; DUP ; ADD } ;
+      SWAP ;
+      DROP } |}]
+
+let%expect_test "fold_left referencing outside var" =
+  (*
+    let outside=5 in
+    fold_left [1,2] init=0
+      (acc,x)-> (fst(acc) + outside) + snd(acc)
+  *)
+  let coll = cons (int 1) (cons (int 2) (nil int_ty)) in
+  let fold_body =
+    add
+      (add (car (variable (var "acc") (mk_tuple_ty [int_ty; int_ty])))
+           (variable (var "outside") int_ty))
+      (cdr (variable (var "acc") (mk_tuple_ty [int_ty; int_ty])))
+  in
+  let expr =
+    let_in (var "outside") ~rhs:(int 5)
+      ~in_:
+        (fold_left coll ~init:(int 0)
+          ~fold:{ lam_var=(var "acc", mk_tuple_ty [int_ty; int_ty]); body=fold_body })
+  in
+  test_and_print "fold_left referencing outside var" expr;
+  [%expect {|
+    --- fold_left referencing outside var ---
+    Node: Let_in
+      luv = {acc, outside} nuv = {}
+      let_var=outside
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Fold_left
+        luv = {acc, outside} nuv = {}
+        collection:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Const
+            luv = {} nuv = {}
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Const
+              luv = {} nuv = {}
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+        init:
+        Node: Const
+          luv = {} nuv = {}
+        lam_var=acc
+        body:
+        Node: Prim
+          luv = {acc} nuv = {}
+          args:
+          Node: Prim
+            luv = {acc} nuv = {}
+            args:
+            Node: Prim
+              luv = {acc} nuv = {}
+              args:
+              Node: Variable
+                luv = {acc} nuv = {}
+                var=acc
+            Node: Variable
+              luv = {} nuv = {}
+              var=outside
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Variable
+              luv = {} nuv = {}
+              var=acc
+
+    { PUSH int 5 ;
+      PUSH int 0 ;
+      NIL int ;
+      PUSH int 2 ;
+      CONS ;
+      PUSH int 1 ;
+      CONS ;
+      ITER { SWAP ; PAIR ; DUP 1 ; CDR ; DUP 3 ; DIG 2 ; CAR ; ADD ; ADD } ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH int 5 ;
+      PUSH int 0 ;
+      PUSH (list int) { 1 ; 2 } ;
+      ITER { SWAP ; PAIR ; DUP ; CDR ; DUP 3 ; DIG 2 ; CAR ; ADD ; ADD } ;
+      SWAP ;
+      DROP } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 21. FOLD_RIGHT overshadow lam_var + referencing outer var           *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_fold_right" =
+  let coll = cons (int 1) (cons (int 2) (nil int_ty)) in
+  let init_expr = int 0 in
+  let lam_body =
+    let_in (var "acc") ~rhs:(int 999)
+      ~in_:(sub
+              (cdr (variable (var "acc") (mk_tuple_ty [int_ty; int_ty])))
+              (car (variable (var "acc") (mk_tuple_ty [int_ty; int_ty]))))
+  in
+  let expr =
+    let_in (var "unused") ~rhs:(int 666)
+      ~in_:
+        (fold_right coll ~init:init_expr
+          ~fold:{ lam_var=(var "acc", mk_tuple_ty [int_ty; int_ty]); body=lam_body })
+  in
+  test_and_print "test_fold_right" expr;
+  [%expect {|
+    --- test_fold_right ---
+    Node: Let_in
+      luv = {acc, unused} nuv = {unused}
+      let_var=unused
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Fold_right
+        luv = {acc} nuv = {}
+        collection:
+        Node: Prim
+          luv = {} nuv = {}
+          args:
+          Node: Const
+            luv = {} nuv = {}
+          Node: Prim
+            luv = {} nuv = {}
+            args:
+            Node: Const
+              luv = {} nuv = {}
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+        init:
+        Node: Const
+          luv = {} nuv = {}
+        lam_var=acc
+        body:
+        Node: Let_in
+          luv = {acc} nuv = {}
+          let_var=acc
+          rhs:
+          Node: Const
+            luv = {} nuv = {}
+          in_:
+          Node: Prim
+            luv = {acc} nuv = {}
+            args:
+            Node: Prim
+              luv = {acc} nuv = {}
+              args:
+              Node: Variable
+                luv = {acc} nuv = {}
+                var=acc
+            Node: Prim
+              luv = {} nuv = {}
+              args:
+              Node: Variable
+                luv = {} nuv = {}
+                var=acc
+
+    { PUSH int 666 ;
+      DROP ;
+      PUSH int 0 ;
+      NIL int ;
+      PUSH int 2 ;
+      CONS ;
+      PUSH int 1 ;
+      CONS ;
+      NIL int ;
+      SWAP ;
+      ITER { CONS } ;
+      ITER { PAIR ; PUSH int 999 ; DUP 1 ; CAR ; SWAP ; CDR ; SUB ; SWAP ; DROP } }
+
+    Optimised:
+    { PUSH int 0 ;
+      NIL int ;
+      PUSH (list int) { 1 ; 2 } ;
+      ITER { CONS } ;
+      ITER { DROP 2 ; PUSH int 999 ; UNPAIR ; SWAP ; SUB } } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 22. LET_TUPLE_IN overshadow many components, referencing only some   *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_let_tuple_in" =
+  let triple =
+    tuple (Row.Node [
+      Row.Leaf(None, int 1);
+      Row.Leaf(None, int 2);
+      Row.Leaf(None, int 3)
+    ])
+  in
+  let expr =
+    let_tuple_in [var "a"; var "b"; var "a"]  (* overshadow a *)
+      ~rhs:triple
+      ~in_:(add (variable (var "a") int_ty) (variable (var "b") int_ty))
+  in
+  test_and_print "test_let_tuple_in" expr;
+  [%expect {|
+    --- test_let_tuple_in ---
+    Node: Let_tuple_in
+      luv = {a, b} nuv = {}
+      components=[a;b;a]
+      rhs:
+      Node: Tuple
+        luv = {} nuv = {}
+        Leaf label=<no-label>
+        Node: Const
+          luv = {} nuv = {}
+        Leaf label=<no-label>
+        Node: Const
+          luv = {} nuv = {}
+        Leaf label=<no-label>
+        Node: Const
+          luv = {} nuv = {}
+      in_:
+      Node: Prim
+        luv = {a, b} nuv = {}
+        args:
+        Node: Variable
+          luv = {a} nuv = {}
+          var=a
+        Node: Variable
+          luv = {b} nuv = {}
+          var=b
+
+    { PUSH int 3 ;
+      PUSH int 2 ;
+      PUSH int 1 ;
+      PAIR 3 ;
+      UNPAIR 3 ;
+      SWAP ;
+      SWAP ;
+      ADD ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH int 3 ; PUSH int 2 ; PUSH int 1 ; DIG 2 ; DROP ; ADD } |}]
+
+let%expect_test "let_tuple_in referencing multiple times, plus an unused" =
+  (*
+    let triple=(1,2,3)
+    let_tuple_in [a,b,c] = triple in
+      let unused=999 in
+      a + b + c
+  *)
+  let triple_expr =
+    tuple (Row.Node [
+      Row.Leaf(None, int 1);
+      Row.Leaf(None, int 2);
+      Row.Leaf(None, int 3)
+    ])
+  in
+  let expr =
+    let_in (var "triple") ~rhs:triple_expr
+      ~in_:
+        (let_tuple_in [var "a"; var "b"; var "c"]
+          ~rhs:(variable (var "triple") (mk_tuple_ty [int_ty; int_ty; int_ty]))
+          ~in_:
+            (let_in (var "unused") ~rhs:(int 999)
+              ~in_:(add (variable (var "a") int_ty)
+                      (add (variable (var "b") int_ty)
+                           (variable (var "c") int_ty)))))
+  in
+  test_and_print "let_tuple_in referencing multiple times, plus an unused" expr;
+  [%expect {|
+    --- let_tuple_in referencing multiple times, plus an unused ---
+    Node: Let_in
+      luv = {a, b, c, triple, unused} nuv = {}
+      let_var=triple
+      rhs:
+      Node: Tuple
+        luv = {} nuv = {}
+        Leaf label=<no-label>
+        Node: Const
+          luv = {} nuv = {}
+        Leaf label=<no-label>
+        Node: Const
+          luv = {} nuv = {}
+        Leaf label=<no-label>
+        Node: Const
+          luv = {} nuv = {}
+      in_:
+      Node: Let_tuple_in
+        luv = {a, b, c, triple, unused} nuv = {}
+        components=[a;b;c]
+        rhs:
+        Node: Variable
+          luv = {triple} nuv = {}
+          var=triple
+        in_:
+        Node: Let_in
+          luv = {a, b, c, unused} nuv = {unused}
+          let_var=unused
+          rhs:
+          Node: Const
+            luv = {} nuv = {}
+          in_:
+          Node: Prim
+            luv = {a, b, c} nuv = {}
+            args:
+            Node: Variable
+              luv = {a} nuv = {}
+              var=a
+            Node: Prim
+              luv = {b, c} nuv = {}
+              args:
+              Node: Variable
+                luv = {b} nuv = {}
+                var=b
+              Node: Variable
+                luv = {c} nuv = {}
+                var=c
+
+    { PUSH int 3 ;
+      PUSH int 2 ;
+      PUSH int 1 ;
+      PAIR 3 ;
+      UNPAIR 3 ;
+      PUSH int 999 ;
+      DROP ;
+      DIG 2 ;
+      DIG 2 ;
+      ADD ;
+      SWAP ;
+      ADD }
+
+    Optimised:
+    { PUSH int 3 ; PUSH int 2 ; PUSH int 1 ; DUG 2 ; ADD ; ADD } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 23. TUPLE referencing multiple overshadow variables                 *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_tuple" =
+  let expr =
+    tuple (Row.Node [
+      Row.Leaf(None, let_in (var "x") ~rhs:(int 10) ~in_:(variable (var "x") int_ty));
+      Row.Leaf(None, variable (var "unused2") int_ty)
+    ])
+  in
+  test_and_print "test_tuple" expr;
+  [%expect {|
+    --- test_tuple ---
+    Node: Tuple
+      luv = {unused2, x} nuv = {}
+      Leaf label=<no-label>
+      Node: Let_in
+        luv = {x} nuv = {}
+        let_var=x
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Variable
+          luv = {x} nuv = {}
+          var=x
+      Leaf label=<no-label>
+      Node: Variable
+        luv = {unused2} nuv = {}
+        var=unused2
+
+    { NEVER }
+
+    Optimised:
+    { NEVER } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 24. PROJ overshadow referencing outer var + partial usage           *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_proj" =
+  let triple =
+    tuple (Row.Node [
+      Row.Leaf(None, variable (var "alpha") int_ty);
+      Row.Leaf(None, int 999);
+      Row.Leaf(None, int 123)
+    ])
+  in
+  let expr = proj triple ~path:(Row.Path.Here [0]) in
+  test_and_print "test_proj" expr;
+  [%expect {|
+    --- test_proj ---
+    Node: Proj
+      luv = {alpha} nuv = {}
+      Node: Tuple
+        luv = {alpha} nuv = {}
+        Leaf label=<no-label>
+        Node: Variable
+          luv = {alpha} nuv = {}
+          var=alpha
+        Leaf label=<no-label>
+        Node: Const
+          luv = {} nuv = {}
+        Leaf label=<no-label>
+        Node: Const
+          luv = {} nuv = {}
+
+    { PUSH int 123 ; PUSH int 999 ; NEVER }
+
+    Optimised:
+    { PUSH int 123 ; PUSH int 999 ; NEVER } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 25. UPDATE overshadow with let_in on update value                   *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_update" =
+  let pair_expr =
+    tuple (Row.Node [
+      Row.Leaf(None, int 10);
+      Row.Leaf(None, int 20)
+    ])
+  in
+  let upd_expr =
+    let_in (var "u") ~rhs:(int 999)
+      ~in_:(variable (var "u") int_ty)
+  in
+  let expr =
+    update_tuple pair_expr ~component:(Row.Path.Here [1]) ~update:upd_expr
+  in
+  test_and_print "test_update" expr;
+  [%expect {|
+    --- test_update ---
+    Node: Update
+      luv = {u} nuv = {}
+      tuple:
+      Node: Tuple
+        luv = {} nuv = {}
+        Leaf label=<no-label>
+        Node: Const
+          luv = {} nuv = {}
+        Leaf label=<no-label>
+        Node: Const
+          luv = {} nuv = {}
+      update:
+      Node: Let_in
+        luv = {u} nuv = {}
+        let_var=u
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Variable
+          luv = {u} nuv = {}
+          var=u
+
+    { PUSH int 20 ;
+      PUSH int 10 ;
+      PAIR ;
+      DUP 1 ;
+      GET 2 ;
+      DROP ;
+      PUSH int 999 ;
+      UPDATE 2 }
+
+    Optimised:
+    { PUSH int 20 ; PUSH int 10 ; PAIR ; PUSH int 999 ; UPDATE 2 } |}]
+
+let%expect_test "update_tuple referencing multiple outside vars in update" =
+  (*
+     let base= (10,20)
+     update base component=1 with let tmp=9 in tmp + outside
+  *)
+  let pair_expr =
+    tuple (Row.Node [
+      Row.Leaf(None, int 10);
+      Row.Leaf(None, int 20)
+    ])
+  in
+  let upd_expr =
+    let_in (var "tmp") ~rhs:(int 9)
+      ~in_:(add (variable (var "tmp") int_ty) (variable (var "outsideU") int_ty))
+  in
+  let expr =
+    let_in (var "outsideU") ~rhs:(int 100)
+      ~in_:(update_tuple pair_expr ~component:(Row.Path.Here [1]) ~update:upd_expr)
+  in
+  test_and_print "update_tuple referencing multiple outside vars in update" expr;
+  [%expect {|
+    --- update_tuple referencing multiple outside vars in update ---
+    Node: Let_in
+      luv = {outsideU, tmp} nuv = {}
+      let_var=outsideU
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Update
+        luv = {outsideU, tmp} nuv = {}
+        tuple:
+        Node: Tuple
+          luv = {} nuv = {}
+          Leaf label=<no-label>
+          Node: Const
+            luv = {} nuv = {}
+          Leaf label=<no-label>
+          Node: Const
+            luv = {} nuv = {}
+        update:
+        Node: Let_in
+          luv = {outsideU, tmp} nuv = {}
+          let_var=tmp
+          rhs:
+          Node: Const
+            luv = {} nuv = {}
+          in_:
+          Node: Prim
+            luv = {outsideU, tmp} nuv = {}
+            args:
+            Node: Variable
+              luv = {tmp} nuv = {}
+              var=tmp
+            Node: Variable
+              luv = {outsideU} nuv = {}
+              var=outsideU
+
+    { PUSH int 100 ;
+      PUSH int 20 ;
+      PUSH int 10 ;
+      PAIR ;
+      DUP 1 ;
+      GET 2 ;
+      DROP ;
+      PUSH int 9 ;
+      DIG 2 ;
+      SWAP ;
+      ADD ;
+      UPDATE 2 }
+
+    Optimised:
+    { PUSH int 100 ;
+      PUSH int 20 ;
+      PUSH int 10 ;
+      PAIR ;
+      PUSH int 9 ;
+      DIG 2 ;
+      ADD ;
+      UPDATE 2 } |}]
+
+
+(* -------------------------------------------------------------------- *)
+(* 26. RAW_MICHELSON overshadow in args                                *)
+(* -------------------------------------------------------------------- *)
+module MA = Michelson.Ast
+let push_int n = Tezos_micheline.Micheline.Prim (Ast_builder.Dummy_range.v, "PUSH", [Tezos_micheline.Micheline.Prim (Ast_builder.Dummy_range.v, "int", [], []); Tezos_micheline.Micheline.Int (Ast_builder.Dummy_range.v, Z.of_int n)], [])
+
+let%expect_test "test_raw_michelson" =
+  let code_ast = Tezos_micheline.Micheline.Seq(Ast_builder.Dummy_range.v, [ push_int 42 ]) in
+  let arg1 = let_in (var "unusedR") ~rhs:(int 7) ~in_:(variable (var "unusedR") int_ty) in
+  let arg2 = variable (var "x") int_ty in
+  let expr = raw_michelson code_ast [arg1; arg2] int_ty in
+  test_and_print "test_raw_michelson" expr;
+  [%expect {|
+    --- test_raw_michelson ---
+    Node: Raw_michelson
+      luv = {unusedR, x} nuv = {}
+      args:
+      Node: Let_in
+        luv = {unusedR} nuv = {}
+        let_var=unusedR
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Variable
+          luv = {unusedR} nuv = {}
+          var=unusedR
+      Node: Variable
+        luv = {x} nuv = {}
+        var=x
+
+    { NEVER }
+
+    Optimised:
+    { NEVER } |}]
+        
+let%expect_test "raw_michelson overshadow multiple args" =
+  (*
+    raw_michelson {PUSH int 42} [
+      let x=10 in x,
+      let x=999 in x
+    ] int
+  *)
+  let code_ast = Tezos_micheline.Micheline.Seq(Ast_builder.Dummy_range.v, [ push_int 42 ]) in
+  let arg1 = let_in (var "x") ~rhs:(int 10) ~in_:(variable (var "x") int_ty) in
+  let arg2 = let_in (var "x") ~rhs:(int 999) ~in_:(variable (var "x") int_ty) in
+  let expr = raw_michelson code_ast [arg1; arg2] int_ty in
+  test_and_print "raw_michelson overshadow multiple args" expr;
+  [%expect{|
+    --- raw_michelson overshadow multiple args ---
+    Node: Raw_michelson
+      luv = {x} nuv = {}
+      args:
+      Node: Let_in
+        luv = {x} nuv = {}
+        let_var=x
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Variable
+          luv = {x} nuv = {}
+          var=x
+      Node: Let_in
+        luv = {x} nuv = {}
+        let_var=x
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Variable
+          luv = {x} nuv = {}
+          var=x
+
+    { PUSH int 999 ; PUSH int 10 ; { PUSH int 42 } }
+
+    Optimised:
+    { PUSH int 999 ; PUSH int 10 ; PUSH int 42 } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 27. CREATE_CONTRACT overshadow code var, referencing multiple unused *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_create_contract" =
+  let param_storage_ty = mk_tuple_ty [nat_ty; nat_ty] in
+  let code_body =
+    let_tuple_in [var "p"; var "s"]
+      ~rhs:(variable (var "args") param_storage_ty)
+      ~in_:(add (variable (var "p") nat_ty) (variable (var "s") nat_ty))
+  in
+  let expr =
+    let_in (var "unusedCC") ~rhs:(string "no use") (* overshadow or never used var *)
+      ~in_:
+        (create_contract
+          ~storage:nat_ty
+          ~code:{ lam_var=(var "args", param_storage_ty); body=code_body }
+          ~delegate:(variable (var "del") (option_ty key_hash_ty))
+          ~initial_balance:(variable (var "bal") mutez_ty)
+          ~initial_storage:(let_in (var "args") ~rhs:(nat 99) ~in_:(nat 100)))
+  in
+  test_and_print "test_create_contract" expr;
+  [%expect {|
+    --- test_create_contract ---
+    Node: Let_in
+      luv = {args, bal, del, p, s, unusedCC} nuv = {unusedCC}
+      let_var=unusedCC
+      rhs:
+      Node: Const
+        luv = {} nuv = {}
+      in_:
+      Node: Create_contract
+        luv = {args, bal, del, p, s} nuv = {}
+        lam_var=args
+        delegate:
+        Node: Variable
+          luv = {del} nuv = {}
+          var=del
+        initial_balance:
+        Node: Variable
+          luv = {bal} nuv = {}
+          var=bal
+        initial_storage:
+        Node: Let_in
+          luv = {args} nuv = {}
+          let_var=args
+          rhs:
+          Node: Const
+            luv = {} nuv = {}
+          in_:
+          Node: Const
+            luv = {} nuv = {}
+        code body:
+        Node: Let_tuple_in
+          luv = {args, p, s} nuv = {}
+          components=[p;s]
+          rhs:
+          Node: Variable
+            luv = {args} nuv = {}
+            var=args
+          in_:
+          Node: Prim
+            luv = {p, s} nuv = {}
+            args:
+            Node: Variable
+              luv = {p} nuv = {}
+              var=p
+            Node: Variable
+              luv = {s} nuv = {}
+              var=s
+
+    { PUSH string "no use" ;
+      DROP ;
+      PUSH nat 99 ;
+      PUSH nat 100 ;
+      SWAP ;
+      DROP ;
+      NEVER }
+
+    Optimised:
+    { PUSH nat 100 ; NEVER } |}]
+
+(* -------------------------------------------------------------------- *)
+(* 28. GLOBAL_CONSTANT overshadow multiple arguments                   *)
+(* -------------------------------------------------------------------- *)
+let%expect_test "test_global_constant" =
+  let arg1 =
+    let_in (var "x") ~rhs:(int 1)
+      ~in_:(variable (var "x") int_ty)
+  in
+  let arg2 =
+    let_in (var "x") ~rhs:(int 99)
+      ~in_:(variable (var "x") int_ty)
+  in
+  let expr =
+    global_constant "SomeGlobalHash" [arg1; arg2] int_ty
+  in
+  test_and_print "test_global_constant" expr;
+  [%expect {|
+    --- test_global_constant ---
+    Node: Global_constant
+      luv = {x} nuv = {}
+      hash=SomeGlobalHash
+      args:
+      Node: Let_in
+        luv = {x} nuv = {}
+        let_var=x
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Variable
+          luv = {x} nuv = {}
+          var=x
+      Node: Let_in
+        luv = {x} nuv = {}
+        let_var=x
+        rhs:
+        Node: Const
+          luv = {} nuv = {}
+        in_:
+        Node: Variable
+          luv = {x} nuv = {}
+          var=x
+
+    { PUSH int 99 ; PUSH int 1 ; constant "SomeGlobalHash" }
+
+    Optimised:
+    { PUSH int 99 ; PUSH int 1 ; constant "SomeGlobalHash" } |}]

--- a/test/test_nodes.ml
+++ b/test/test_nodes.ml
@@ -1,0 +1,4142 @@
+open Core
+open Lltz_ir.Ast_builder.With_dummy
+module Ast_builder = Lltz_ir.Ast_builder
+module LM = Lltz_codegen
+module Row = Lltz_ir.Row 
+module Tezos_micheline = Tezos_micheline 
+
+let empty_stack : LM.Stack.t = []
+
+let compile_and_collect_instructions ?(optimize = false)  expr =
+  let compiled_instruction = LM.compile_to_micheline ~optimize expr in
+  [compiled_instruction empty_stack]
+
+let print_instructions instructions =
+  List.iter ~f:(fun instruction ->
+    Michelson.Ast.pp Format.std_formatter instruction;
+    Format.print_newline ()
+  ) instructions;
+  Format.print_flush ()
+
+let test_expr ?(optimise = true) expr =
+  let instructions = compile_and_collect_instructions expr in
+  print_instructions instructions;
+  if optimise then
+    (Printf.printf "\nOptimised: \n";
+    let optimised_instructions = compile_and_collect_instructions ~optimize:true expr in
+    print_instructions optimised_instructions)
+  else ()
+
+
+let%expect_test "unit" =
+  test_expr (unit);
+  [%expect {|
+    { UNIT }
+
+    Optimised:
+    { UNIT } |}]
+
+
+(* Bool Tests *)
+let%expect_test "bool true" =
+  test_expr (bool true);
+  [%expect {|
+    { PUSH bool True }
+
+    Optimised:
+    { PUSH bool True } |}]
+
+let%expect_test "bool false" =
+  test_expr (bool false);
+  [%expect {|
+    { PUSH bool False }
+
+    Optimised:
+    { PUSH bool False } |}]
+
+(* Nat Tests *)
+let%expect_test "nat zero" =
+  test_expr (nat 0);
+  [%expect {|
+    { PUSH nat 0 }
+
+    Optimised:
+    { PUSH nat 0 } |}]
+
+let%expect_test "nat 42" =
+  test_expr (nat 42);
+  [%expect {|
+    { PUSH nat 42 }
+
+    Optimised:
+    { PUSH nat 42 } |}]
+
+let%expect_test "nat large" =
+  test_expr (nat 999999999999999999);
+  [%expect {|
+    { PUSH nat 999999999999999999 }
+
+    Optimised:
+    { PUSH nat 999999999999999999 } |}]
+
+(* Int Tests *)
+let%expect_test "int zero" =
+  test_expr (int 0);
+  [%expect {|
+    { PUSH int 0 }
+
+    Optimised:
+    { PUSH int 0 } |}]
+
+let%expect_test "int positive" =
+  test_expr (int 123456);
+  [%expect {|
+    { PUSH int 123456 }
+
+    Optimised:
+    { PUSH int 123456 } |}]
+
+let%expect_test "int negative" =
+  test_expr (int (-999999));
+  [%expect {|
+    { PUSH int -999999 }
+
+    Optimised:
+    { PUSH int -999999 } |}]
+
+(* Mutez Tests *)
+let%expect_test "mutez zero" =
+  test_expr (mutez 0);
+  [%expect {|
+    { PUSH mutez 0 }
+
+    Optimised:
+    { PUSH mutez 0 } |}]
+
+let%expect_test "mutez small" =
+  test_expr (mutez 123);
+  [%expect {|
+    { PUSH mutez 123 }
+
+    Optimised:
+    { PUSH mutez 123 } |}]
+
+let%expect_test "mutez large" = 
+  test_expr (mutez 10000000);
+  [%expect {|
+    { PUSH mutez 10000000 }
+
+    Optimised:
+    { PUSH mutez 10000000 } |}]
+
+(* String Tests *)
+let%expect_test "string empty" =
+  test_expr (string "");
+  [%expect {|
+    { PUSH string "" }
+
+    Optimised:
+    { PUSH string "" } |}]
+
+let%expect_test "string ascii" =
+  test_expr (string "hello");
+  [%expect {|
+    { PUSH string "hello" }
+
+    Optimised:
+    { PUSH string "hello" } |}]
+
+let%expect_test "string unicode" =
+  test_expr (string "こんにちは");
+  [%expect {|
+    { PUSH string "こんにちは" }
+
+    Optimised:
+    { PUSH string "こんにちは" } |}]
+
+(* Key Tests *)
+let%expect_test "key example1" =
+  test_expr (key "edpkExampleKeyString");
+  [%expect {|
+    { PUSH key "edpkExampleKeyString" }
+
+    Optimised:
+    { PUSH key "edpkExampleKeyString" } |}]
+
+(* Key_hash Tests *)
+let%expect_test "key_hash tz1" =
+  test_expr (key_hash "tz1abc123abc123abc123");
+  [%expect {|
+    { PUSH key_hash "tz1abc123abc123abc123" }
+
+    Optimised:
+    { PUSH key_hash "tz1abc123abc123abc123" } |}]
+
+let%expect_test "key_hash tz2" =
+  test_expr (key_hash "tz2xyz456xyz456xyz456");
+  [%expect {|
+    { PUSH key_hash "tz2xyz456xyz456xyz456" }
+
+    Optimised:
+    { PUSH key_hash "tz2xyz456xyz456xyz456" } |}]
+
+(* Bytes Tests *)
+let%expect_test "bytes empty" =
+  test_expr (bytes "0x");
+  [%expect {|
+    { PUSH bytes 0x3078 }
+
+    Optimised:
+    { PUSH bytes 0x3078 } |}]
+
+let%expect_test "bytes small" =
+  test_expr (bytes "0xFF");
+  [%expect {|
+    { PUSH bytes 0x30784646 }
+
+    Optimised:
+    { PUSH bytes 0x30784646 } |}]
+
+let%expect_test "bytes bigger" =
+  test_expr (bytes "0xDEADBEEF");
+  [%expect {|
+    { PUSH bytes 0x30784445414442454546 }
+
+    Optimised:
+    { PUSH bytes 0x30784445414442454546 } |}]
+
+(* Chain_id Tests *)
+let%expect_test "chain_id mainnet" =
+  test_expr (chain_id "NetXdQprcVkpaWU");
+  [%expect {|
+    { PUSH chain_id "NetXdQprcVkpaWU" }
+
+    Optimised:
+    { PUSH chain_id "NetXdQprcVkpaWU" } |}]
+
+let%expect_test "chain_id ghostnet" =
+  test_expr (chain_id "NetXnHfVqm9iesp");
+  [%expect {|
+    { PUSH chain_id "NetXnHfVqm9iesp" }
+
+    Optimised:
+    { PUSH chain_id "NetXnHfVqm9iesp" } |}]
+
+(* Address Tests *)
+let%expect_test "address kt1 contract" =
+  test_expr (address_const "KT1ExampleContractAddress");
+  [%expect {|
+    { PUSH address "KT1ExampleContractAddress" }
+
+    Optimised:
+    { PUSH address "KT1ExampleContractAddress" } |}]
+
+let%expect_test "address tz1 implicit" =
+  test_expr (address_const "tz1ExampleImplicitAddress");
+  [%expect {|
+    { PUSH address "tz1ExampleImplicitAddress" }
+
+    Optimised:
+    { PUSH address "tz1ExampleImplicitAddress" } |}]
+
+(* Timestamp Tests *)
+let%expect_test "timestamp epoch" =
+  test_expr (timestamp "1970-01-01T00:00:00Z");
+  [%expect {|
+    { PUSH timestamp 0 }
+
+    Optimised:
+    { PUSH timestamp 0 } |}]
+
+(* Large future date, or something well beyond typical usage. *)
+let%expect_test "timestamp far-future" =
+  test_expr (timestamp "9999-12-31T23:59:59Z");
+  [%expect {|
+    { PUSH timestamp 253402300799 }
+
+    Optimised:
+    { PUSH timestamp 253402300799 } |}]
+
+(* BLS12-381 G1, G2, FR Tests *)
+let%expect_test "bls12_381_g1 short" =
+  test_expr (bls12_381_g1 "BLS12_381_G1ShortExample");
+  [%expect {|
+    { PUSH bls12_381_g1 0x424c5331325f3338315f473153686f72744578616d706c65 }
+
+    Optimised:
+    { PUSH bls12_381_g1 0x424c5331325f3338315f473153686f72744578616d706c65 } |}]
+
+let%expect_test "bls12_381_g2 short" =
+  test_expr (bls12_381_g2 "BLS12_381_G2ShortExample");
+  [%expect {|
+    { PUSH bls12_381_g2 0x424c5331325f3338315f473253686f72744578616d706c65 }
+
+    Optimised:
+    { PUSH bls12_381_g2 0x424c5331325f3338315f473253686f72744578616d706c65 } |}]
+
+let%expect_test "bls12_381_fr short" =
+  test_expr (bls12_381_fr "BLS12_381_FRShortExample");
+  [%expect {|
+    { PUSH bls12_381_fr 0x424c5331325f3338315f465253686f72744578616d706c65 }
+
+    Optimised:
+    { PUSH bls12_381_fr 0x424c5331325f3338315f465253686f72744578616d706c65 } |}]
+
+(* Signature Tests *)
+let%expect_test "signature short" =
+  test_expr (signature "edsigShortExampleSignature");
+  [%expect {|
+    { PUSH signature "edsigShortExampleSignature" }
+
+    Optimised:
+    { PUSH signature "edsigShortExampleSignature" } |}]
+
+let%expect_test "signature typical" =
+  test_expr (signature "edsigthT3ab6iK1ZPw6u9JN7nUeadfZtQ1Qvo8CeCD3ScH7GpdiQA69rVbX7fNCRbs6Sr9aBii1qmuXun5qRmEuA9N2Dg9LGQdN");
+  [%expect {|
+    { PUSH signature
+           "edsigthT3ab6iK1ZPw6u9JN7nUeadfZtQ1Qvo8CeCD3ScH7GpdiQA69rVbX7fNCRbs6Sr9aBii1qmuXun5qRmEuA9N2Dg9LGQdN" }
+
+    Optimised:
+    { PUSH signature
+           "edsigthT3ab6iK1ZPw6u9JN7nUeadfZtQ1Qvo8CeCD3ScH7GpdiQA69rVbX7fNCRbs6Sr9aBii1qmuXun5qRmEuA9N2Dg9LGQdN" } |}]
+
+
+let%expect_test "variable x" =
+  test_expr (let_in (var "x") ~rhs:(nat 1) ~in_:(variable (var "x") (nat_ty)));
+  [%expect {|
+    { PUSH nat 1 }
+
+    Optimised:
+    { PUSH nat 1 } |}]
+
+
+let%expect_test "variable usage: let_in (bind + reference)" =
+let expr =
+  let_in (var "x") ~rhs:(nat 42) ~in_:(variable (var "x") (nat_ty))
+in
+test_expr expr;
+[%expect {|
+  { PUSH nat 42 }
+
+  Optimised:
+  { PUSH nat 42 } |}]
+
+let%expect_test "nested let_in (two bindings, referencing each other)" =
+  (* let x = 42 in
+       let y = x + 1 in
+         y
+  *)
+  let expr =
+    let_in (var "x") ~rhs:(nat 42)
+      ~in_:(
+        let_in (var "y")
+          ~rhs:(add (variable (var "x") nat_ty) (nat 1))
+          ~in_:(variable (var "y") nat_ty)
+      )
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 42 ; PUSH nat 1 ; SWAP ; ADD }
+
+    Optimised:
+    { PUSH nat 42 ; PUSH nat 1 ; ADD } |}]
+  
+let%expect_test "let_in variable shadowing" =
+  let expr =
+    let_in (var "x") ~rhs:(nat 10)
+      ~in_:(
+        let_in (var "x")
+          ~rhs:(add (variable (var "x") nat_ty) (nat 5))
+          ~in_:(variable (var "x") nat_ty)
+      )
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 10 ; PUSH nat 5 ; DUP 2 ; ADD ; SWAP ; DROP }
+
+    Optimised:
+    { PUSH nat 10 ; PUSH nat 5 ; ADD } |}]
+  
+let%expect_test "let_mut_in usage (assign, reassign, read)" =
+  let expr =
+    let_mut_in (mut_var "x") ~rhs:(nat 0)
+      ~in_:
+        (let_in (var "unused_after_assign")
+           ~rhs:(assign (mut_var "x") (nat 1))
+           ~in_:(deref (mut_var "x") nat_ty))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 0 ; PUSH nat 1 ; DUG 1 ; DIG 0 ; DROP ; UNIT ; DROP }
+
+    Optimised:
+    { PUSH nat 1 } |}]
+
+let%expect_test "multiple sequential assign" =
+  let mut_x = mut_var "x" in
+  let expr =
+    let_mut_in mut_x ~rhs:(nat 10)
+      ~in_:
+        (let_in (var "ignore1")
+          ~rhs:(
+            assign mut_x (add (deref mut_x nat_ty) (nat 1))
+          )
+          ~in_:
+            (let_in (var "ignore2")
+              ~rhs:(
+                assign mut_x (add (deref mut_x nat_ty) (nat 2))
+              )
+              ~in_:
+                (deref mut_x nat_ty)))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 10 ;
+      PUSH nat 1 ;
+      DUP 2 ;
+      ADD ;
+      DUG 1 ;
+      DIG 0 ;
+      DROP ;
+      UNIT ;
+      DROP ;
+      PUSH nat 2 ;
+      DUP 2 ;
+      ADD ;
+      DUG 1 ;
+      DIG 0 ;
+      DROP ;
+      UNIT ;
+      DROP }
+
+    Optimised:
+    { PUSH nat 10 ; PUSH nat 1 ; ADD ; PUSH nat 2 ; ADD } |}]
+
+let%expect_test "assign inside nested if_bool" =
+  let mut_x = mut_var "x" in
+  let nested_if =
+    if_bool (lt (nat 3) (nat 4))
+      ~then_:(assign mut_x (add (deref mut_x nat_ty) (nat 200)))
+      ~else_:(assign mut_x (add (deref mut_x nat_ty) (nat 300)))
+  in
+  let main_if =
+    if_bool (eq (nat 1) (nat 2))
+      ~then_:(assign mut_x (add (deref mut_x nat_ty) (nat 100)))
+      ~else_:nested_if
+  in
+  let expr =
+    let_mut_in mut_x ~rhs:(nat 0)
+      ~in_:
+        (let_in (var "ignored")
+          ~rhs:main_if
+          ~in_:(deref mut_x nat_ty))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 0 ;
+      PUSH nat 2 ;
+      PUSH nat 1 ;
+      COMPARE ;
+      EQ ;
+      IF { PUSH nat 100 ; DUP 2 ; ADD ; DUG 1 ; DIG 0 ; DROP ; UNIT }
+         { PUSH nat 4 ;
+           PUSH nat 3 ;
+           COMPARE ;
+           LT ;
+           IF { PUSH nat 200 ; DUP 2 ; ADD ; DUG 1 ; DIG 0 ; DROP ; UNIT }
+              { PUSH nat 300 ; DUP 2 ; ADD ; DUG 1 ; DIG 0 ; DROP ; UNIT } } ;
+      DROP }
+
+    Optimised:
+    { PUSH nat 0 ; PUSH nat 200 ; ADD } |}]
+
+let%expect_test "assign same value repeatedly" =
+  let mut_x = mut_var "x" in
+  let expr =
+    let_mut_in mut_x ~rhs:(nat 5)
+      ~in_:
+        (let_in (var "ignore1")
+          ~rhs:(assign mut_x (nat 5))
+          ~in_:
+            (let_in (var "ignore2")
+              ~rhs:(assign mut_x (nat 5))
+              ~in_:(deref mut_x nat_ty)))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 5 ;
+      PUSH nat 5 ;
+      DUG 1 ;
+      DIG 0 ;
+      DROP ;
+      UNIT ;
+      DROP ;
+      PUSH nat 5 ;
+      DUG 1 ;
+      DIG 0 ;
+      DROP ;
+      UNIT ;
+      DROP }
+
+    Optimised:
+    { PUSH nat 5 } |}]
+
+let%expect_test "assign referencing the updated var" =
+  let mut_x = mut_var "x" in
+  let first_assign =
+    assign mut_x (add (deref mut_x nat_ty) (nat 10))
+  in
+  let second_assign =
+    assign mut_x
+      (add (deref mut_x nat_ty) (deref mut_x nat_ty))
+  in
+  let expr =
+    let_mut_in mut_x ~rhs:(nat 10)
+      ~in_:
+        (let_in (var "ignore1") ~rhs:first_assign
+          ~in_:
+            (let_in (var "ignore2") ~rhs:second_assign
+              ~in_:(deref mut_x nat_ty)))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 10 ;
+      PUSH nat 10 ;
+      DUP 2 ;
+      ADD ;
+      DUG 1 ;
+      DIG 0 ;
+      DROP ;
+      UNIT ;
+      DROP ;
+      DUP 1 ;
+      DUP 2 ;
+      ADD ;
+      DUG 1 ;
+      DIG 0 ;
+      DROP ;
+      UNIT ;
+      DROP }
+
+    Optimised:
+    { PUSH nat 10 ; DUP ; ADD ; DUP ; ADD } |}]
+
+let%expect_test "assign inside while" =
+  let mut_x = mut_var "x" in
+  let body_expr =
+    assign mut_x
+      (add (add (deref mut_x nat_ty) (deref mut_x nat_ty)) (nat 1))
+  in
+  let while_expr =
+    while_ (lt (deref mut_x nat_ty) (nat 3)) ~body:body_expr
+  in
+  let expr =
+    let_mut_in mut_x ~rhs:(nat 0)
+      ~in_:
+        (let_in (var "ignore_while") ~rhs:while_expr
+          ~in_:(deref mut_x nat_ty))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 0 ;
+      PUSH nat 3 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { PUSH nat 1 ;
+             DUP 2 ;
+             DUP 3 ;
+             ADD ;
+             ADD ;
+             DUG 1 ;
+             DIG 0 ;
+             DROP ;
+             UNIT ;
+             DROP ;
+             PUSH nat 3 ;
+             DUP 2 ;
+             COMPARE ;
+             LT } ;
+      UNIT ;
+      DROP }
+
+    Optimised:
+    { PUSH nat 0 ;
+      PUSH nat 3 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { PUSH nat 1 ; SWAP ; DUP ; ADD ; ADD ; PUSH nat 3 ; DUP 2 ; COMPARE ; LT } } |}]
+
+let%expect_test "assign same var multiple branches" =
+  let mut_x = mut_var "x" in
+  let condition = eq (deref mut_x nat_ty) (nat 100) in
+  let then_branch =
+    assign mut_x (sub (deref mut_x nat_ty) (nat 50))
+  in
+  let else_branch =
+    assign mut_x (sub (deref mut_x nat_ty) (nat 10))
+  in
+  let expr =
+    let_mut_in mut_x ~rhs:(nat 100)
+      ~in_:
+        (if_bool condition
+          ~then_:then_branch
+          ~else_:else_branch)
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 100 ;
+      PUSH nat 100 ;
+      DUP 2 ;
+      COMPARE ;
+      EQ ;
+      IF { DROP ; PUSH nat 50 ; NEVER } { DROP ; PUSH nat 10 ; NEVER } }
+
+    Optimised:
+    { PUSH bool True ;
+      IF { PUSH nat 50 ; NEVER } { PUSH nat 10 ; NEVER } } |}]
+
+let%expect_test "assign inside for loop" =
+  let idx = mut_var "i" in
+  let mut_x = mut_var "x" in
+  let for_body_expr =
+    assign mut_x (add (deref mut_x nat_ty) (deref idx nat_ty))
+  in
+  let cond_expr = lt (deref idx nat_ty) (nat 4) in
+  let update_expr =
+    assign (mut_var "i") (add (deref (mut_var "i") nat_ty) (nat 1))
+  in
+  let for_expr =
+    for_ idx
+      ~init:(nat 0)
+      ~cond:cond_expr
+      ~update:update_expr
+      ~body:for_body_expr
+  in
+  let expr =
+    let_mut_in mut_x ~rhs:(nat 0)
+      ~in_:(
+        let_mut_in (mut_var "i") ~rhs:(nat 0)
+          ~in_:(
+            let_in (var "ignore_for") ~rhs:for_expr
+              ~in_:(deref mut_x nat_ty)
+          )
+      )
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 0 ;
+      PUSH nat 0 ;
+      PUSH nat 0 ;
+      PUSH nat 4 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { DUP 1 ;
+             DUP 4 ;
+             ADD ;
+             DUG 3 ;
+             DIG 2 ;
+             DROP ;
+             UNIT ;
+             DROP ;
+             PUSH nat 1 ;
+             DUP 2 ;
+             ADD ;
+             DUG 1 ;
+             DIG 0 ;
+             DROP ;
+             UNIT ;
+             DROP ;
+             PUSH nat 4 ;
+             DUP 2 ;
+             COMPARE ;
+             LT } ;
+      DROP ;
+      UNIT ;
+      DROP ;
+      SWAP ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH nat 0 ;
+      DUP ;
+      DUP ;
+      PUSH nat 4 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { DUP ;
+             DIG 3 ;
+             ADD ;
+             DUG 2 ;
+             PUSH nat 1 ;
+             ADD ;
+             PUSH nat 4 ;
+             DUP 2 ;
+             COMPARE ;
+             LT } ;
+      DROP 2 } |}]
+
+let%expect_test "assign same var different type" =
+  (* Not valid when type-checked. *)
+  let mut_x = mut_var "x" in
+  let expr =
+    let_mut_in mut_x ~rhs:(int 123)
+      ~in_:
+        (assign mut_x (string "changed"))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH int 123 ; DROP ; PUSH string "changed" ; DROP ; UNIT }
+
+    Optimised:
+    { UNIT } |}]
+
+let%expect_test "let_in + if_bool" =
+  let expr =
+    let_in (var "b") ~rhs:(bool true)
+      ~in_:(if_bool (variable (var "b") bool_ty)
+               ~then_:(nat 10)
+               ~else_:(nat 20))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH bool True ; IF { PUSH nat 10 } { PUSH nat 20 } }
+
+    Optimised:
+    { PUSH nat 10 } |}]
+  
+let%expect_test "let_in referencing previous var inside if_bool" =
+  let expr =
+    let_in (var "x") ~rhs:(nat 1)
+      ~in_:
+        (let_in (var "y") ~rhs:(nat 2)
+          ~in_:
+            (if_bool (bool true)
+              ~then_:(variable (var "x") nat_ty)
+              ~else_:(variable (var "y") nat_ty)))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 1 ;
+      PUSH nat 2 ;
+      PUSH bool True ;
+      IF { DROP } { SWAP ; DROP } }
+
+    Optimised:
+    { PUSH nat 1 } |}]
+
+let%expect_test "nested let_in" =
+  let expr =
+    let_in (var "x") ~rhs:(nat 10)
+      ~in_:(
+        let_in (var "y") ~rhs:(int (-5))
+          ~in_:
+            (app
+              (lambda (var "z", nat_ty)
+                ~body:(mul (variable (var "z") nat_ty) (nat 2)))
+              (add (variable (var "y") int_ty) (variable (var "x") nat_ty)))
+      )
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 10 ;
+      PUSH int -5 ;
+      SWAP ;
+      SWAP ;
+      ADD ;
+      LAMBDA nat nat { PUSH nat 2 ; SWAP ; MUL } ;
+      SWAP ;
+      EXEC }
+
+    Optimised:
+    { PUSH nat 10 ; PUSH int -5 ; ADD ; PUSH nat 2 ; SWAP ; MUL } |}]
+  
+let%expect_test "lambda that uses let_in" =
+  let expr =
+    lambda (var "x", nat_ty)
+      ~body:(
+        let_in (var "z") ~rhs:(nat 5)
+          ~in_:(add (variable (var "x") nat_ty) (variable (var "z") nat_ty))
+      )
+  in
+  test_expr expr;
+  [%expect {|
+    { LAMBDA nat nat { PUSH nat 5 ; SWAP ; ADD } }
+
+    Optimised:
+    { LAMBDA nat nat { PUSH nat 5 ; ADD } } |}]
+
+let%expect_test "recursive lambda usage" =
+let lam_rec_expr =
+  lambda_rec (var "f")
+    (var "x", nat_ty)
+    ~body:(
+      if_bool
+        (le (variable (var "x") nat_ty) (nat 0))
+        ~then_:(nat 1)
+        ~else_:(app
+                  (variable (var "f") (function_ty nat_ty nat_ty))
+                  (sub (variable (var "x") nat_ty) (nat 1)))
+    )
+in
+test_expr lam_rec_expr;
+[%expect {|
+  { LAMBDA_REC
+      nat
+      nat
+      { SWAP ;
+        SWAP ;
+        PUSH nat 0 ;
+        DUP 2 ;
+        COMPARE ;
+        LE ;
+        IF { SWAP ; DROP ; DROP ; PUSH nat 1 }
+           { PUSH nat 1 ; SWAP ; SUB ; SWAP ; SWAP ; EXEC } } }
+
+  Optimised:
+  { LAMBDA_REC
+      nat
+      nat
+      { DUP ;
+        INT ;
+        LE ;
+        IF { DROP 2 ; PUSH nat 1 } { PUSH int -1 ; ADD ; EXEC } } } |}]
+  
+let%expect_test "let_mut_in + assign in if_bool" =
+  let expr =
+    let_mut_in (mut_var "x") ~rhs:(nat 100)
+      ~in_:
+        (if_bool (bool false)
+          ~then_:(assign (mut_var "x") (nat 200))
+          ~else_:(assign (mut_var "x") (nat 300)))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 100 ;
+      DROP ;
+      PUSH bool False ;
+      IF { PUSH nat 200 ; DROP ; UNIT } { PUSH nat 300 ; DROP ; UNIT } }
+
+    Optimised:
+    { UNIT } |}]
+
+let%expect_test "lambda returning same type: bool -> bool" =
+  let lam_expr =
+    lambda (var "x", bool_ty)
+      ~body:(variable (var "x") bool_ty)
+  in
+  test_expr lam_expr;
+  [%expect {|
+    { LAMBDA bool bool {} }
+
+    Optimised:
+    { LAMBDA bool bool {} } |}]
+
+let%expect_test "lambda returning different type: string -> bool" =
+  let lam_expr =
+    lambda (var "x", string_ty)
+      ~body:(
+        if_bool
+          (eq (variable (var "x") string_ty) (string "secret"))
+          ~then_:(bool true)
+          ~else_:(bool false)
+      )
+  in
+  test_expr lam_expr;
+  [%expect {|
+    { LAMBDA
+        string
+        bool
+        { PUSH string "secret" ;
+          SWAP ;
+          COMPARE ;
+          EQ ;
+          IF { PUSH bool True } { PUSH bool False } } }
+
+    Optimised:
+    { LAMBDA string bool { PUSH string "secret" ; COMPARE ; EQ } } |}]
+
+let%expect_test "lambda returning tuple" =
+  let lam_expr =
+    lambda (var "x", address_ty)
+      ~body:(
+        tuple
+          (mk_row [
+             Leaf (None, now);
+             Leaf (None, variable (var "x") address_ty)
+           ])
+      )
+  in
+  test_expr lam_expr;
+  [%expect {|
+    { LAMBDA address (pair timestamp address) { NOW ; PAIR } }
+
+    Optimised:
+    { LAMBDA address (pair timestamp address) { NOW ; PAIR } } |}]
+
+let%expect_test "lambda_rec factorial" =
+  let n_var = var "n" in
+  let n_var_ty = int_ty in
+  let f_var = var "f" in
+
+  let body_expr =
+    if_bool
+      (le (variable n_var n_var_ty) (int 1))
+      ~then_:(int 1)
+      ~else_:(
+        mul
+          (variable n_var n_var_ty)
+          (app (variable f_var (function_ty int_ty int_ty))
+               (sub (variable n_var n_var_ty) (int 1)))
+      )
+  in
+
+  let lam_rec_expr =
+    lambda_rec f_var (n_var, n_var_ty) ~body:body_expr
+  in
+  test_expr lam_rec_expr;
+  [%expect {|
+    { LAMBDA_REC
+        int
+        int
+        { SWAP ;
+          SWAP ;
+          PUSH int 1 ;
+          DUP 2 ;
+          COMPARE ;
+          LE ;
+          IF { SWAP ; DROP ; DROP ; PUSH int 1 }
+             { PUSH int 1 ; DUP 2 ; SUB ; DIG 2 ; SWAP ; EXEC ; SWAP ; MUL } } }
+
+    Optimised:
+    { LAMBDA_REC
+        int
+        int
+        { PUSH int 1 ;
+          DUP 2 ;
+          COMPARE ;
+          LE ;
+          IF { DROP 2 ; PUSH int 1 }
+             { PUSH int 1 ; DUP 2 ; SUB ; DIG 2 ; SWAP ; EXEC ; SWAP ; MUL } } } |}]
+
+let%expect_test "nested lambda" =
+  let inner =
+    lambda (var "y", nat_ty)
+      ~body:(add (variable (var "y") nat_ty) (nat 2))
+  in
+  let outer =
+    lambda (var "x", nat_ty)
+      ~body:inner
+  in
+  test_expr outer;
+  [%expect {|
+    { LAMBDA
+        nat
+        (lambda nat nat)
+        { LAMBDA nat nat { PUSH nat 2 ; SWAP ; ADD } ; SWAP ; DROP } }
+
+    Optimised:
+    { LAMBDA nat (lambda nat nat) { DROP ; LAMBDA nat nat { PUSH nat 2 ; ADD } } } |}]
+
+let%expect_test "lambda in let" =
+  let lambda_expr =
+    lambda (var "y", nat_ty)
+      ~body:(mul (nat 3) (variable (var "y") nat_ty))
+  in
+  let expr =
+    let_in (var "x") ~rhs:lambda_expr
+      ~in_:(app (variable (var "x") (function_ty nat_ty nat_ty)) (nat 5))
+  in
+  test_expr expr;
+  [%expect {|
+    { LAMBDA nat nat { PUSH nat 3 ; MUL } ; PUSH nat 5 ; SWAP ; SWAP ; EXEC }
+
+    Optimised:
+    { LAMBDA nat nat { PUSH nat 3 ; MUL } ; PUSH nat 5 ; EXEC } |}]
+
+let%expect_test "if with lambda" =
+  let lambda_then =
+    lambda (var "x", nat_ty)
+      ~body:(add (variable (var "x") nat_ty) (nat 2))
+  in
+  let lambda_else =
+    lambda (var "y", nat_ty)
+      ~body:(sub (variable (var "y") nat_ty) (nat 3))
+  in
+  let expr =
+    if_bool
+      (neq (nat 1) (nat 2))
+      ~then_:lambda_then
+      ~else_:lambda_else
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 2 ;
+      PUSH nat 1 ;
+      COMPARE ;
+      NEQ ;
+      IF { LAMBDA nat nat { PUSH nat 2 ; SWAP ; ADD } }
+         { LAMBDA nat int { PUSH nat 3 ; SWAP ; SUB } } }
+
+    Optimised:
+    { PUSH int -1 ;
+      NEQ ;
+      IF { LAMBDA nat nat { PUSH nat 2 ; ADD } }
+         { LAMBDA nat int { PUSH int -3 ; ADD } } } |}]
+
+let%expect_test "app: lambda (string->bool) applied to a string" =
+  let fun_expr =
+    lambda (var "x", string_ty)
+      ~body:(eq (variable (var "x") string_ty) (string "hello"))
+  in
+  let app_expr =
+    app fun_expr (string "test")
+  in
+  test_expr app_expr;
+  [%expect {|
+    { PUSH string "test" ;
+      LAMBDA string bool { PUSH string "hello" ; SWAP ; COMPARE ; EQ } ;
+      SWAP ;
+      EXEC }
+
+    Optimised:
+    { PUSH string "test" ; PUSH string "hello" ; COMPARE ; EQ } |}]
+
+let%expect_test "let_mut_in: assign string" =
+  let expr =
+    let_mut_in (mut_var "s") ~rhs:(string "hello")
+      ~in_:
+        (let_in (var "ignore")
+          ~rhs:(assign (mut_var "s") (string "world"))
+          ~in_:(deref (mut_var "s") string_ty))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH string "hello" ;
+      PUSH string "world" ;
+      DUG 1 ;
+      DIG 0 ;
+      DROP ;
+      UNIT ;
+      DROP }
+
+    Optimised:
+    { PUSH string "world" } |}]
+
+let%expect_test "deref inside lambda body" =
+  let mut_counter = mut_var "counter" in
+  let expr =
+    let_mut_in mut_counter ~rhs:(nat 0)
+      ~in_:
+        (lambda (var "u", unit_ty)
+          ~body:(deref mut_counter nat_ty))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 0 ;
+      LAMBDA (pair nat unit) nat { UNPAIR ; SWAP ; DROP } ;
+      SWAP ;
+      APPLY }
+
+    Optimised:
+    { LAMBDA (pair nat unit) nat { CAR } ; PUSH nat 0 ; APPLY } |}]
+
+let%expect_test "assign inside if_bool" =
+  let mut_x = mut_var "x" in
+  let expr =
+    let_mut_in mut_x ~rhs:(nat 42)
+      ~in_:
+        (if_bool (bool true)
+          ~then_:(assign mut_x (nat 100))
+          ~else_:(assign mut_x (nat 200)))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 42 ;
+      DROP ;
+      PUSH bool True ;
+      IF { PUSH nat 100 ; DROP ; UNIT } { PUSH nat 200 ; DROP ; UNIT } }
+
+    Optimised:
+    { UNIT } |}]
+
+let%expect_test "app of lambda_rec factorial with let_in" =
+  let n_var = var "n" in
+  let n_var_ty = int_ty in
+  let f_var = var "f" in
+  let body_expr =
+    if_bool
+      (le (variable n_var n_var_ty) (int 1))
+      ~then_:(int 1)
+      ~else_:
+        (mul
+          (variable n_var n_var_ty)
+          (app (variable f_var (function_ty int_ty int_ty))
+               (sub (variable n_var n_var_ty) (int 1))))
+  in
+  let factorial_rec =
+    lambda_rec f_var (n_var, n_var_ty) ~body:body_expr
+  in
+  let call_factorial_5 =
+    app factorial_rec (int 5)
+  in
+  test_expr call_factorial_5;
+  [%expect {|
+    { PUSH int 5 ;
+      LAMBDA_REC
+        int
+        int
+        { SWAP ;
+          SWAP ;
+          PUSH int 1 ;
+          DUP 2 ;
+          COMPARE ;
+          LE ;
+          IF { SWAP ; DROP ; DROP ; PUSH int 1 }
+             { PUSH int 1 ; DUP 2 ; SUB ; DIG 2 ; SWAP ; EXEC ; SWAP ; MUL } } ;
+      SWAP ;
+      EXEC }
+
+    Optimised:
+    { LAMBDA_REC
+        int
+        int
+        { PUSH int 1 ;
+          DUP 2 ;
+          COMPARE ;
+          LE ;
+          IF { DROP 2 ; PUSH int 1 }
+             { PUSH int 1 ; DUP 2 ; SUB ; DIG 2 ; SWAP ; EXEC ; SWAP ; MUL } } ;
+      PUSH int 5 ;
+      EXEC } |}]
+
+
+let%expect_test "if bool 1" =
+  let e = if_bool (bool true) ~then_:(string "A") ~else_:(string "B") in
+  test_expr e;
+  [%expect {|
+    { PUSH bool True ; IF { PUSH string "A" } { PUSH string "B" } }
+
+    Optimised:
+    { PUSH string "A" } |}]
+
+let%expect_test "if bool 2" =
+  let e = if_bool (eq (nat 2) (nat 2)) ~then_:(int 100) ~else_:(int (-1)) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 2 ;
+      PUSH nat 2 ;
+      COMPARE ;
+      EQ ;
+      IF { PUSH int 100 } { PUSH int -1 } }
+
+    Optimised:
+    { PUSH int 100 } |}]
+
+let%expect_test "nested if_bool" =
+  let expr =
+    if_bool
+      (eq (nat 1) (nat 2))
+      ~then_:
+        (if_bool
+           (le (nat 1) (nat 10))
+           ~then_:(nat 1)
+           ~else_:(nat 2))
+      ~else_:(nat 3)
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 2 ;
+      PUSH nat 1 ;
+      COMPARE ;
+      EQ ;
+      IF { PUSH nat 10 ;
+           PUSH nat 1 ;
+           COMPARE ;
+           LE ;
+           IF { PUSH nat 1 } { PUSH nat 2 } }
+         { PUSH nat 3 } }
+
+    Optimised:
+    { PUSH nat 3 } |}]
+
+let%expect_test "if none 1" =
+  let some_val = some (nat 10) in
+  let e = if_none some_val ~none:(string "none") ~some:
+    {lam_var = (var "val", nat_ty); body = (add (variable (var "val") nat_ty) (nat 5))} in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 10 ;
+      SOME ;
+      IF_NONE { PUSH string "none" } { PUSH nat 5 ; SWAP ; ADD } }
+
+    Optimised:
+    { PUSH nat 10 ;
+      SOME ;
+      IF_NONE { PUSH string "none" } { PUSH nat 5 ; ADD } } |}]
+
+let%expect_test "if none 2" =
+  let none_val = none (bool_ty) in
+  let e = if_none none_val 
+    ~none:(bool true) 
+    ~some:{lam_var =(var "val", bool_ty); body = (not (variable (var "val") bool_ty))} in
+  test_expr e;
+  [%expect {|
+    { NONE bool ; IF_NONE { PUSH bool True } { NOT } }
+
+    Optimised:
+    { NONE bool ; IF_NONE { PUSH bool True } { NOT } } |}]
+
+let%expect_test "if cons 1" =
+  let lst = cons (nat 1) (cons (nat 2) (nil nat_ty)) in
+  let e = if_cons lst ~empty:(nat 0)
+    ~nonempty:{
+      lam_var1 = (var "hd", nat_ty);
+      lam_var2 = (var "tl", list_ty nat_ty);
+      body = string "nonempty"
+    }
+  in
+  test_expr e;
+  [%expect {|
+    { NIL nat ;
+      PUSH nat 2 ;
+      CONS ;
+      PUSH nat 1 ;
+      CONS ;
+      IF_CONS { DROP ; DROP ; PUSH string "nonempty" } { PUSH nat 0 } }
+
+    Optimised:
+    { PUSH (list nat) { 1 ; 2 } ;
+      IF_CONS { DROP 2 ; PUSH string "nonempty" } { PUSH nat 0 } } |}]
+
+let%expect_test "if cons 2" =
+  let empty_list = nil string_ty in
+  let e = if_cons empty_list ~empty:(string "empty")
+    ~nonempty:{
+      lam_var1 = (var "hd", string_ty);
+      lam_var2 = (var "tl", list_ty string_ty);
+      body = string "nonempty"
+    }
+  in
+  test_expr e;
+  [%expect {|
+    { NIL string ;
+      IF_CONS { DROP ; DROP ; PUSH string "nonempty" } { PUSH string "empty" } }
+
+    Optimised:
+    { NIL string ;
+      IF_CONS { DROP 2 ; PUSH string "nonempty" } { PUSH string "empty" } } |}]
+
+let%expect_test "if left" =
+  let left_expr = left (None, None, bool_ty) (bool false) in
+  let e = if_left left_expr
+    ~left:{ lam_var = (var "l", bool_ty); body = string "left" }
+    ~right:{ lam_var = (var "r", bool_ty); body = string "right" }
+  in
+  test_expr e;
+  [%expect {|
+    { PUSH bool False ;
+      LEFT bool ;
+      IF_LEFT { DROP ; PUSH string "left" } { DROP ; PUSH string "right" } }
+
+    Optimised:
+    { PUSH bool False ;
+      LEFT bool ;
+      IF_LEFT { DROP ; PUSH string "left" } { DROP ; PUSH string "right" } } |}]
+
+let%expect_test "if left 2" =
+  let right_expr = right (None, None, bool_ty) (bool true) in
+  let e = if_left right_expr
+    ~left:{ lam_var = (var "l", bool_ty); body = int 0 }
+    ~right:{ lam_var = (var "r", bool_ty); body = int 1 }
+  in
+  test_expr e;
+  [%expect {|
+    { PUSH bool True ;
+      RIGHT bool ;
+      IF_LEFT { DROP ; PUSH int 0 } { DROP ; PUSH int 1 } }
+
+    Optimised:
+    { PUSH bool True ;
+      RIGHT bool ;
+      IF_LEFT { DROP ; PUSH int 0 } { DROP ; PUSH int 1 } } |}]
+
+let%expect_test "while" =
+  let e = while_ (lt (variable (var "i") int_ty) (int 3))
+      ~body:(assign (mut_var "i") (add (deref (mut_var "i") int_ty) (int 1))) in
+  test_expr (let_mut_in (mut_var "i") ~rhs:(int 0) ~in_:e);
+  [%expect {|
+    { PUSH int 0 ;
+      PUSH int 3 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { PUSH int 1 ;
+             DUP 2 ;
+             ADD ;
+             DUG 1 ;
+             DIG 0 ;
+             DROP ;
+             UNIT ;
+             DROP ;
+             PUSH int 3 ;
+             DUP 2 ;
+             COMPARE ;
+             LT } ;
+      UNIT ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH int 0 ;
+      PUSH int 3 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { PUSH int 1 ; ADD ; PUSH int 3 ; DUP 2 ; COMPARE ; LT } ;
+      DROP ;
+      UNIT } |}]
+
+let%expect_test "while with complex body" =
+  let body_expr =
+    let_in (var "x") ~rhs:(nat 7)
+      ~in_:
+        (if_bool
+          (ge (variable (var "x") nat_ty) (nat 5))
+          ~then_:(assign (mut_var "x") (nat 2))
+          ~else_:(assign (mut_var "x") (nat 2)))
+  in
+  let expr =
+    while_ (le (nat 0) (nat 10)) ~body:body_expr
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 10 ;
+      PUSH nat 0 ;
+      COMPARE ;
+      LE ;
+      LOOP { PUSH nat 7 ;
+             PUSH nat 5 ;
+             DUP 2 ;
+             COMPARE ;
+             GE ;
+             IF { DROP ; PUSH nat 2 ; DROP ; UNIT }
+                { DROP ; PUSH nat 2 ; DROP ; UNIT } ;
+             DROP ;
+             PUSH nat 10 ;
+             PUSH nat 0 ;
+             COMPARE ;
+             LE } ;
+      UNIT }
+
+    Optimised:
+    { PUSH int -1 ; LE ; LOOP { PUSH int -1 ; LE } ; UNIT } |}]
+
+let%expect_test "while left" =
+  let start_val = left (None, None, bool_ty) (bool false) in
+  let e = while_left start_val ~body:{
+    lam_var = (var "v", bool_ty);
+    body = if_bool (variable (var "v") bool_ty)
+      ~then_:(right (None, None, string_ty) (string "done"))
+      ~else_:(left (None, None, bool_ty) (bool true))
+  } in
+  test_expr e;
+  [%expect {|
+    { PUSH bool False ;
+      LEFT bool ;
+      LEFT string ;
+      LOOP_LEFT
+        { IF { PUSH string "done" ; RIGHT string } { PUSH bool True ; LEFT bool } } }
+
+    Optimised:
+    { PUSH bool False ;
+      LEFT bool ;
+      LEFT string ;
+      LOOP_LEFT
+        { IF { PUSH string "done" ; RIGHT string } { PUSH bool True ; LEFT bool } } } |}]
+
+let%expect_test "for" =
+  let i = mut_var "i" in
+  let e = for_ i ~init:(nat 0) ~cond:(lt (deref i nat_ty) (nat 3))
+      ~update:(assign (mut_var "i") (add (deref (mut_var "i") nat_ty) (nat 1)))
+      ~body:(string "looping") in
+  test_expr (let_mut_in (mut_var "i") ~rhs:(nat 0) ~in_:e);
+  [%expect {|
+    { PUSH nat 0 ;
+      PUSH nat 0 ;
+      PUSH nat 3 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { PUSH string "looping" ;
+             DROP ;
+             PUSH nat 1 ;
+             DUP 2 ;
+             ADD ;
+             DUG 1 ;
+             DIG 0 ;
+             DROP ;
+             UNIT ;
+             DROP ;
+             PUSH nat 3 ;
+             DUP 2 ;
+             COMPARE ;
+             LT } ;
+      DROP ;
+      UNIT ;
+      SWAP ;
+      DROP }
+
+    Optimised:
+    { PUSH nat 0 ;
+      PUSH nat 3 ;
+      DUP 2 ;
+      COMPARE ;
+      LT ;
+      LOOP { PUSH nat 1 ; ADD ; PUSH nat 3 ; DUP 2 ; COMPARE ; LT } ;
+      DROP ;
+      UNIT } |}]
+
+let%expect_test "for each" =
+  let items = cons (string "one") (cons (string "two") (nil string_ty)) in
+  let e = for_each items ~body:{
+    lam_var = (var "s", string_ty);
+    body = bool true
+  } in
+  test_expr e;
+  [%expect {|
+    { NIL string ;
+      PUSH string "two" ;
+      CONS ;
+      PUSH string "one" ;
+      CONS ;
+      ITER { DROP ; PUSH bool True ; DROP } ;
+      UNIT }
+
+    Optimised:
+    { PUSH (list string) { "one" ; "two" } ; ITER { DROP } ; UNIT } |}]
+
+let%expect_test "map1" =
+  let lst = cons (int 1) (cons (int 2) (nil int_ty)) in
+  let e = map lst ~map:{ lam_var = (var "x", int_ty); body = add (variable (var "x") int_ty) (int 10) } in
+  test_expr e;
+  [%expect {|
+    { NIL int ;
+      PUSH int 2 ;
+      CONS ;
+      PUSH int 1 ;
+      CONS ;
+      MAP { PUSH int 10 ; SWAP ; ADD } }
+
+    Optimised:
+    { PUSH (list int) { 1 ; 2 } ; MAP { PUSH int 10 ; ADD } } |}]
+
+let%expect_test "map2" =
+  let opt_val = some (bool true) in
+  let e = map opt_val ~map:{ lam_var = (var "b", bool_ty); body = not (variable (var "b") bool_ty) }  in
+  test_expr e;
+  [%expect {|
+    { PUSH bool True ; SOME ; MAP { NOT } }
+
+    Optimised:
+    { PUSH bool True ; SOME ; MAP { NOT } } |}]
+
+let%expect_test "map with operations" =
+  let coll = cons (nat 1) (cons (nat 2) (cons (nat 3) (nil nat_ty))) in
+  let lam_map = annon_function "x" nat_ty ~body:(add (variable (var "x") nat_ty) (nat 10))
+  in
+  let expr = map coll ~map:lam_map in
+  test_expr expr;
+  [%expect {|
+    { NIL nat ;
+      PUSH nat 3 ;
+      CONS ;
+      PUSH nat 2 ;
+      CONS ;
+      PUSH nat 1 ;
+      CONS ;
+      MAP { PUSH nat 10 ; SWAP ; ADD } }
+
+    Optimised:
+    { PUSH (list nat) { 1 ; 2 ; 3 } ; MAP { PUSH nat 10 ; ADD } } |}]
+
+let%expect_test "fold left" =
+  let lst = cons (nat 2) (cons (nat 3) (nil nat_ty)) in
+  let e = fold_left lst ~init:(nat 1) ~fold:{ lam_var = (var "acc_x", tuple_ty (mk_row [
+    Leaf (None, nat_ty);
+    Leaf (None, nat_ty)
+  ]));
+  body = mul
+    (car (variable (var "acc_x") (tuple_ty (mk_row [
+       Leaf (None, nat_ty);
+       Leaf (None, nat_ty)
+     ]))))
+    (cdr (variable (var "acc_x") (tuple_ty (mk_row [
+       Leaf (None, nat_ty);
+       Leaf (None, nat_ty)
+     ]))))
+} in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 1 ;
+      NIL nat ;
+      PUSH nat 3 ;
+      CONS ;
+      PUSH nat 2 ;
+      CONS ;
+      ITER { SWAP ; PAIR ; DUP 1 ; CDR ; SWAP ; CAR ; MUL } }
+
+    Optimised:
+    { PUSH nat 1 ; PUSH (list nat) { 2 ; 3 } ; ITER { SWAP ; MUL } } |}]
+
+let%expect_test "fold_left with operations" =
+  let coll = cons (nat 1) (cons (nat 2) (cons (nat 3) (nil nat_ty))) in
+  let fold_body =
+    annon_function "acc_x" (tuple_ty (mk_row [
+        Leaf (None, nat_ty); 
+        Leaf (None, nat_ty)
+      ]))
+      ~body:(add
+        (car (variable (var "acc_x") (tuple_ty (mk_row [
+          Leaf (None, nat_ty);
+          Leaf (None, nat_ty)
+        ]))))
+        (cdr (variable (var "acc_x") (tuple_ty (mk_row [
+          Leaf (None, nat_ty);
+          Leaf (None, nat_ty)
+        ])))))
+  in
+  let expr = fold_left coll ~init:(nat 0) ~fold:fold_body in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 0 ;
+      NIL nat ;
+      PUSH nat 3 ;
+      CONS ;
+      PUSH nat 2 ;
+      CONS ;
+      PUSH nat 1 ;
+      CONS ;
+      ITER { SWAP ; PAIR ; DUP 1 ; CDR ; SWAP ; CAR ; ADD } }
+
+    Optimised:
+    { PUSH nat 0 ; PUSH (list nat) { 1 ; 2 ; 3 } ; ITER { ADD } } |}]
+
+let%expect_test "fold right" =
+  let lst = cons (int 1) (cons (int 2) (nil int_ty)) in
+  let e = fold_right lst ~init:(int 0) ~fold:{ lam_var = (var "elem_acc", tuple_ty (mk_row [
+    Leaf (None, int_ty);
+    Leaf (None, int_ty)
+  ]));
+  body = add
+    (car (variable (var "elem_acc") (tuple_ty (mk_row [
+       Leaf (None, int_ty);
+       Leaf (None, int_ty)
+     ]))))
+    (cdr (variable (var "elem_acc") (tuple_ty (mk_row [
+       Leaf (None, int_ty);
+       Leaf (None, int_ty)
+     ]))))
+} in
+  test_expr e;
+  [%expect {|
+    { PUSH int 0 ;
+      NIL int ;
+      PUSH int 2 ;
+      CONS ;
+      PUSH int 1 ;
+      CONS ;
+      NIL int ;
+      SWAP ;
+      ITER { CONS } ;
+      ITER { PAIR ; DUP 1 ; CDR ; SWAP ; CAR ; ADD } }
+
+    Optimised:
+    { PUSH int 0 ;
+      NIL int ;
+      PUSH (list int) { 1 ; 2 } ;
+      ITER { CONS } ;
+      ITER { ADD } } |}]
+
+let%expect_test "fold_right with operations" =
+  let coll = cons (nat 1) (cons (nat 2) (cons (nat 3) (nil nat_ty))) in
+  let fold_body =
+    annon_function "x_acc" (tuple_ty (mk_row [
+        Leaf (None, nat_ty);
+        Leaf (None, nat_ty)
+      ]))
+      ~body: (sub (cdr (variable (var "x_acc") (tuple_ty (mk_row [
+        Leaf (None, nat_ty);
+        Leaf (None, nat_ty)
+      ]))))
+      (car (variable (var "x_acc") (tuple_ty (mk_row [
+        Leaf (None, nat_ty);
+        Leaf (None, nat_ty)
+      ])))))
+  in
+  let expr = fold_right coll ~init:(nat 0) ~fold:fold_body in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 0 ;
+      NIL nat ;
+      PUSH nat 3 ;
+      CONS ;
+      PUSH nat 2 ;
+      CONS ;
+      PUSH nat 1 ;
+      CONS ;
+      NIL nat ;
+      SWAP ;
+      ITER { CONS } ;
+      ITER { PAIR ; DUP 1 ; CAR ; SWAP ; CDR ; SUB } }
+
+    Optimised:
+    { PUSH nat 0 ;
+      NIL nat ;
+      PUSH (list nat) { 1 ; 2 ; 3 } ;
+      ITER { CONS } ;
+      ITER { SWAP ; SUB } } |}]
+
+let%expect_test "let tuple in basic" =
+  let rhs_tuple =
+    tuple (mk_row [
+      Leaf (None, nat 1);
+      Leaf (None, bool true)
+    ])
+  in
+  let expr =
+    let_tuple_in
+      [var "x"; var "b"]
+      ~rhs:rhs_tuple
+      ~in_:
+        (if_bool
+          (variable (var "b") bool_ty)
+          ~then_:(add (variable (var "x") nat_ty) (nat 10))
+          ~else_:(nat 0))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH bool True ;
+      PUSH nat 1 ;
+      PAIR ;
+      UNPAIR ;
+      SWAP ;
+      IF { PUSH nat 10 ; SWAP ; ADD } { DROP ; PUSH nat 0 } }
+
+    Optimised:
+    { PUSH nat 1 ; PUSH nat 10 ; ADD } |}]
+
+let%expect_test "let tuple in nested" =
+  let inner_tuple = tuple (mk_row [Leaf (None, int 2); Leaf (None, nat 5)]) in
+  let outer_tuple =
+    tuple (mk_row [
+      Leaf (None, inner_tuple);
+      Leaf (None, bool false)
+    ])
+  in
+  let expr =
+    let_tuple_in
+      [var "p"; var "flag"]
+      ~rhs:outer_tuple
+      ~in_:
+        (if_bool
+          (variable (var "flag") bool_ty)
+          ~then_:(car (variable (var "p") (tuple_ty (mk_row [
+             Leaf (None, int_ty);
+             Leaf (None, nat_ty)
+           ]))))
+          ~else_:(cdr (variable (var "p") (tuple_ty (mk_row [
+             Leaf (None, int_ty);
+             Leaf (None, nat_ty)
+           ])))))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH bool False ;
+      PUSH nat 5 ;
+      PUSH int 2 ;
+      PAIR ;
+      PAIR ;
+      UNPAIR ;
+      SWAP ;
+      IF { CAR } { CDR } }
+
+    Optimised:
+    { PUSH nat 5 } |}]
+
+let%expect_test "nested tuple and projection" =
+  let triple =
+    tuple (mk_row [
+      Leaf (None, nat 1);
+      Leaf (None, nat 2);
+      Leaf (None, nat 3)
+    ])
+  in
+  let expr =
+    let_tuple_in [(var "x"); (var "y"); (var "z")]
+      ~rhs:triple
+      ~in_:
+        (let_in (var "a")
+          ~rhs:(
+            proj
+              (tuple (mk_row [
+                Leaf (None, variable (var "y") nat_ty);
+                Leaf (None, variable (var "z") nat_ty)
+              ]))
+              ~path:(Here [0])
+          )
+          ~in_:(add (variable (var "a") nat_ty) (variable (var "x") nat_ty)))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 3 ;
+      PUSH nat 2 ;
+      PUSH nat 1 ;
+      PAIR 3 ;
+      UNPAIR 3 ;
+      DIG 2 ;
+      DIG 2 ;
+      PAIR ;
+      GET 1 ;
+      SWAP ;
+      SWAP ;
+      ADD }
+
+    Optimised:
+    { PUSH nat 3 ; PUSH nat 2 ; PUSH nat 1 ; DIG 2 ; DROP ; ADD } |}]
+
+let%expect_test "proj second element" =
+  let rhs_tuple =
+    tuple (mk_row [
+      Leaf (None, string "hello");
+      Leaf (None, int 42);
+      Leaf (None, bool false)
+    ])
+  in
+  let second_elem = proj rhs_tuple ~path:(Here [1]) in
+  let expr = second_elem in
+  test_expr expr;
+  [%expect {|
+    { PUSH bool False ; PUSH int 42 ; PUSH string "hello" ; PAIR 3 ; GET 3 }
+
+    Optimised:
+    { PUSH bool False ; PUSH int 42 ; PUSH string "hello" ; PAIR 3 ; GET 3 } |}]
+
+let%expect_test "proj nested element" =
+  let inner = mk_row [Leaf (None, nat 10); Leaf (None, nat 20)] in
+  let outer = tuple (mk_row [Leaf (None, string "s"); inner]) in
+  let extract = proj outer ~path:(Here [1;0]) in
+  let expr = extract in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 20 ; PUSH nat 10 ; PAIR ; PUSH string "s" ; PAIR ; GET 2 ; GET 1 }
+
+    Optimised:
+    { PUSH nat 10 } |}]
+
+let%expect_test "update tuple index" =
+  let original_tuple =
+    tuple (mk_row [
+      Leaf (None, bool true);
+      Leaf (None, nat 123)
+    ])
+  in
+  let updated = update_tuple original_tuple ~component:(Here [1]) ~update:(nat 999) in
+  let expr = updated in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 123 ;
+      PUSH bool True ;
+      PAIR ;
+      DUP 1 ;
+      GET 2 ;
+      DROP ;
+      PUSH nat 999 ;
+      UPDATE 2 }
+
+    Optimised:
+    { PUSH nat 123 ; PUSH bool True ; PAIR ; PUSH nat 999 ; UPDATE 2 } |}]
+
+(* TODO: INJ/MATCH used in SmartPY
+let%expect_test "inj two branch" =
+  let left_or_right =
+    or_ty (Node [
+      Leaf (None, int_ty);
+      Leaf (None, string_ty)
+    ])
+  in
+  let c = Row.Context.Node ([], Row.Context.Hole left_or_right, []) in
+  let expr = inj c (int 42) in
+  test_expr expr;
+  [%expect {||}]
+
+let%expect_test "match two branch left" =
+  let sum_type =
+    mk_type ~range:v (LLTZ.T.Or (R.Node [
+      R.Leaf (None, int_ty);
+      R.Leaf (None, string_ty)
+    ]))
+  in
+  let c = LLTZ.R.Context.Node ([], sum_type, []) in
+  let left_side = inj c (int 7) in
+  let cases =
+    R.Node [
+      R.Leaf (None, { lam_var = (var "l", int_ty); body = nat 999 });
+      R.Leaf (None, { lam_var = (var "r", string_ty); body = nat 111 })
+    ]
+  in
+  let expr = match_ left_side ~cases in
+  test_expr expr;
+  [%expect {||}]
+
+let%expect_test "match two branch right" =
+  let sum_type =
+    mk_type ~range:v (LLTZ.T.Or (R.Node [
+      R.Leaf (None, int_ty);
+      R.Leaf (None, string_ty)
+    ]))
+  in
+  let c = LLTZ.R.Context.Node ([], sum_type, []) in
+  let right_side = inj c (string "abc") in
+  let cases =
+    R.Node [
+      R.Leaf (None, { lam_var = (var "l", int_ty); body = nat 999 });
+      R.Leaf (None, { lam_var = (var "r", string_ty); body = nat 111 })
+    ]
+  in
+  let expr = match_ right_side ~cases in
+  test_expr expr;
+  [%expect {||}]
+
+let%expect_test "match three branch" =
+  let triple_type =
+    mk_type ~range:v (LLTZ.T.Or (R.Node [
+      R.Leaf (Some (R.Label "A"), bool_ty);
+      R.Leaf (Some (R.Label "B"), nat_ty);
+      R.Leaf (Some (R.Label "C"), string_ty)
+    ]))
+  in
+  let c = LLTZ.R.Context.Node (
+    [],
+    triple_type,
+    []
+  )
+  in
+  let triple_inj = inj c (string "tagC") in
+  let cases =
+    R.Node [
+      R.Leaf (Some (R.Label "A"), { lam_var = (var "ab", bool_ty); body = int 1 });
+      R.Leaf (Some (R.Label "B"), { lam_var = (var "bn", nat_ty); body = int 2 });
+      R.Leaf (Some (R.Label "C"), { lam_var = (var "cs", string_ty); body = int 3 })
+    ]
+  in
+  let expr = match_ triple_inj ~cases in
+  test_expr expr;
+  [%expect {||}]
+*)
+
+(* Raw michelson *)
+let push_int n = 
+  let open Tezos_micheline.Micheline in
+  Prim ( Ast_builder.Dummy_range.v, "PUSH", [Int (Ast_builder.Dummy_range.v, Z.of_int n) ], ["int"])
+let seq_of_prim prim = Tezos_micheline.Micheline.Seq (Ast_builder.Dummy_range.v, [prim])
+let seq instrs = Tezos_micheline.Micheline.Seq (Ast_builder.Dummy_range.v, instrs)
+
+
+let%expect_test "raw michelson single push int" =
+  let michelson_ast =
+    seq_of_prim (push_int 42)
+  in
+  let expr = raw_michelson michelson_ast [] int_ty in
+  test_expr ~optimise:false expr;
+  [%expect {| { { PUSH int 42 } } |}]
+
+let%expect_test "raw michelson multiple instructions" =
+  let open Tezos_micheline.Micheline in
+  let michelson_ast =
+    Seq (Ast_builder.Dummy_range.v,
+      [
+        push_int 3;
+        push_int 5;
+        Prim (Ast_builder.Dummy_range.v, "ADD", [], [])
+      ])
+  in
+  let expr = raw_michelson michelson_ast [] int_ty in
+  test_expr ~optimise:false expr;
+  [%expect {| { { PUSH int 3 ; PUSH int 5 ; ADD } } |}]
+
+let%expect_test "raw michelson with arguments" =
+  let open Tezos_micheline.Micheline in
+  let michelson_ast =
+    seq_of_prim
+      (Prim (Ast_builder.Dummy_range.v, "MUL", [], []))
+  in
+  let expr = raw_michelson michelson_ast [int 2; int 8] int_ty in
+  test_expr ~optimise:false expr;
+  [%expect {| { PUSH int 8 ; PUSH int 2 ; { MUL } } |}]
+
+let%expect_test "raw michelson returning string" =
+  let open Tezos_micheline.Micheline in
+  let michelson_ast =
+    Seq (Ast_builder.Dummy_range.v,
+      [
+        Prim (Ast_builder.Dummy_range.v, "PUSH", [String (Ast_builder.Dummy_range.v, "hello")], ["string"])
+      ])
+  in
+  let expr = raw_michelson michelson_ast [] string_ty in
+  test_expr ~optimise:false expr;
+  [%expect {| { { PUSH string "hello" } } |}]
+
+let%expect_test "raw michelson complex seq" =
+  let open Tezos_micheline.Micheline in
+  let michelson_ast =
+    Seq (Ast_builder.Dummy_range.v,
+      [
+        push_int 10;
+        push_int 20;
+        Prim (Ast_builder.Dummy_range.v, "PAIR", [], []);
+        Prim (Ast_builder.Dummy_range.v, "DUP", [], [])
+      ])
+  in
+  let expr = raw_michelson michelson_ast [] (tuple_ty (mk_row [
+    Leaf (None, int_ty);
+    Leaf (None, int_ty)
+  ]))
+  in
+  test_expr ~optimise:false expr;
+  [%expect {| { { PUSH int 10 ; PUSH int 20 ; PAIR ; DUP } } |}]
+
+let operation_list_ty =
+  list_ty (operation_ty)
+
+let return_no_ops stg_expr stg_ty =
+  tuple (mk_row [
+    Leaf (None, nil (operation_ty));
+    Leaf (None, stg_expr)
+  ]),
+  mk_tuple_ty [operation_list_ty; stg_ty]
+
+let%expect_test "create contract unit nat increment" =
+  let storage_ty = nat_ty in
+  let initial_storage_expr = nat 100 in
+  let param_storage_ty =
+    mk_tuple_ty [unit_ty; storage_ty]
+  in
+  let code_lambda =
+        let_tuple_in
+          [var "p"; var "s"]
+          ~rhs:(variable (var "args") param_storage_ty)
+          ~in_:
+            (let new_storage = add (variable (var "s") nat_ty) (nat 1) in
+            let ret_expr, _ret_ty = return_no_ops new_storage nat_ty in
+            ret_expr)
+  in
+  let expr =
+    create_contract
+      ~storage:storage_ty
+      ~code:{ lam_var = (var "args", param_storage_ty); body = code_lambda }
+      ~delegate:(none key_hash_ty)
+      ~initial_balance:(mutez 1_000_000)
+      ~initial_storage:initial_storage_expr
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 100 ;
+      PUSH mutez 1000000 ;
+      NONE key_hash ;
+      CREATE_CONTRACT
+        { parameter unit ;
+          storage nat ;
+          code { UNPAIR ; DROP ; PUSH nat 1 ; SWAP ; ADD ; NIL operation ; PAIR } } ;
+      PAIR }
+
+    Optimised:
+    { PUSH nat 100 ;
+      PUSH mutez 1000000 ;
+      NONE key_hash ;
+      CREATE_CONTRACT
+        { parameter unit ;
+          storage nat ;
+          code { CDR ; PUSH nat 1 ; ADD ; NIL operation ; PAIR } } ;
+      PAIR } |}]
+
+let%expect_test "create contract bool string conditional" =
+  let storage_ty = string_ty in
+  let initial_storage_expr = string "init" in
+  let param_storage_ty =
+    mk_tuple_ty [bool_ty; storage_ty]
+  in
+  let code_lambda =(
+        let_tuple_in
+          [var "flag"; var "st"]
+          ~rhs:(variable (var "args") param_storage_ty)
+          ~in_:
+            (if_bool (variable (var "flag") bool_ty)
+              ~then_:
+                (let ret_expr, _ret_ty = return_no_ops (string "param was true") string_ty in
+                ret_expr)
+              ~else_:
+                (let ret_expr, _ret_ty = return_no_ops (string "param was false") string_ty in
+                ret_expr))
+      )
+  in
+  let expr =
+    create_contract
+      ~storage:storage_ty
+      ~code:{ lam_var = (var "args", param_storage_ty); body = code_lambda }
+      ~delegate:(some (key_hash "tz1DelegateKey"))
+      ~initial_balance:(mutez 2_000_000)
+      ~initial_storage:initial_storage_expr
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH string "init" ;
+      PUSH mutez 2000000 ;
+      PUSH key_hash "tz1DelegateKey" ;
+      SOME ;
+      CREATE_CONTRACT
+        { parameter bool ;
+          storage string ;
+          code { UNPAIR ;
+                 SWAP ;
+                 DROP ;
+                 IF { PUSH string "param was true" ; NIL operation ; PAIR }
+                    { PUSH string "param was false" ; NIL operation ; PAIR } } } ;
+      PAIR }
+
+    Optimised:
+    { PUSH string "init" ;
+      PUSH mutez 2000000 ;
+      PUSH key_hash "tz1DelegateKey" ;
+      SOME ;
+      CREATE_CONTRACT
+        { parameter bool ;
+          storage string ;
+          code { CAR ;
+                 IF { PUSH string "param was true" } { PUSH string "param was false" } ;
+                 NIL operation ;
+                 PAIR } } ;
+      PAIR } |}]
+
+let%expect_test "create contract int int accumulation" =
+  let storage_ty = int_ty in
+  let initial_storage_expr = int 5 in
+  let param_storage_ty =
+    mk_tuple_ty [int_ty; int_ty]
+  in
+  let code_lambda = (
+        let_tuple_in
+          [var "p"; var "s"]
+          ~rhs:(variable (var "args") param_storage_ty)
+          ~in_:
+            (if_bool (eq (variable (var "p") int_ty) (int 0))
+              ~then_:
+                (let ret_expr, _ret_ty = return_no_ops (int 999) int_ty in
+                ret_expr)
+              ~else_:
+                (let new_st = add (variable (var "p") int_ty) (variable (var "s") int_ty) in
+                let ret_expr, _ret_ty = return_no_ops new_st int_ty in
+                ret_expr))
+      )
+  in
+  let expr =
+    create_contract
+      ~storage:storage_ty
+      ~code:{ lam_var = (var "args", param_storage_ty); body = code_lambda }
+      ~delegate:(none key_hash_ty)
+      ~initial_balance:(mutez 9999999)
+      ~initial_storage:initial_storage_expr
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH int 5 ;
+      PUSH mutez 9999999 ;
+      NONE key_hash ;
+      CREATE_CONTRACT
+        { parameter int ;
+          storage int ;
+          code { UNPAIR ;
+                 PUSH int 0 ;
+                 DUP 2 ;
+                 COMPARE ;
+                 EQ ;
+                 IF { DROP ; DROP ; PUSH int 999 ; NIL operation ; PAIR }
+                    { SWAP ; SWAP ; ADD ; NIL operation ; PAIR } } } ;
+      PAIR }
+
+    Optimised:
+    { PUSH int 5 ;
+      PUSH mutez 9999999 ;
+      NONE key_hash ;
+      CREATE_CONTRACT
+        { parameter int ;
+          storage int ;
+          code { UNPAIR ;
+                 DUP ;
+                 EQ ;
+                 IF { DROP 2 ; PUSH int 999 } { ADD } ;
+                 NIL operation ;
+                 PAIR } } ;
+      PAIR } |}]
+
+let%expect_test "create contract nat address no change" =
+  let storage_ty = address_ty in
+  let initial_storage_expr = address_const "KT1InitialAddress" in
+  let param_storage_ty =
+    mk_tuple_ty [nat_ty; address_ty]
+  in
+  let code_lambda =(
+        let_tuple_in
+          [var "p"; var "st"]
+          ~rhs:(variable (var "args") param_storage_ty)
+          ~in_:
+            (let ret_expr, _ret_ty = return_no_ops (variable (var "st") address_ty) address_ty in
+            ret_expr)
+      )
+  in
+  let expr =
+    create_contract
+      ~storage:storage_ty
+      ~code:{ lam_var = (var "args", param_storage_ty); body = code_lambda }
+      ~delegate:(none key_hash_ty)
+      ~initial_balance:(mutez 1234567)
+      ~initial_storage:initial_storage_expr
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH address "KT1InitialAddress" ;
+      PUSH mutez 1234567 ;
+      NONE key_hash ;
+      CREATE_CONTRACT
+        { parameter nat ;
+          storage address ;
+          code { UNPAIR ; DROP ; NIL operation ; PAIR } } ;
+      PAIR }
+
+    Optimised:
+    { PUSH address "KT1InitialAddress" ;
+      PUSH mutez 1234567 ;
+      NONE key_hash ;
+      CREATE_CONTRACT
+        { parameter nat ; storage address ; code { CDR ; NIL operation ; PAIR } } ;
+      PAIR } |}]
+
+let%expect_test "create contract bool flip storage" =
+  let storage_ty = bool_ty in
+  let initial_storage_expr = bool false in
+  let param_storage_ty =
+    mk_tuple_ty [unit_ty; bool_ty]
+  in
+  let code_lambda = (
+        let_tuple_in
+          [var "p"; var "s"]
+          ~rhs:(variable (var "args") param_storage_ty)
+          ~in_:
+            (if_bool (variable (var "s") bool_ty)
+              ~then_:
+                (let ret_expr, _ret_ty = return_no_ops (bool true) bool_ty in
+                ret_expr)
+              ~else_:
+                (let ret_expr, _ret_ty = return_no_ops (bool true) bool_ty in
+                ret_expr))
+      )
+  in
+  let expr =
+    create_contract
+      ~storage:storage_ty
+      ~code:{ lam_var = (var "args", param_storage_ty); body = code_lambda }
+      ~delegate:(none key_hash_ty)
+      ~initial_balance:(mutez 500000)
+      ~initial_storage:initial_storage_expr
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH bool False ;
+      PUSH mutez 500000 ;
+      NONE key_hash ;
+      CREATE_CONTRACT
+        { parameter unit ;
+          storage bool ;
+          code { UNPAIR ;
+                 DROP ;
+                 IF { PUSH bool True ; NIL operation ; PAIR }
+                    { PUSH bool True ; NIL operation ; PAIR } } } ;
+      PAIR }
+
+    Optimised:
+    { PUSH bool False ;
+      PUSH mutez 500000 ;
+      NONE key_hash ;
+      CREATE_CONTRACT
+        { parameter unit ;
+          storage bool ;
+          code { CDR ;
+                 IF { PUSH bool True } { PUSH bool True } ;
+                 NIL operation ;
+                 PAIR } } ;
+      PAIR } |}]
+
+let%expect_test "create contract complex" =
+let storage_ty = nat_ty in
+let param_storage_ty =
+  mk_tuple_ty [nat_ty; nat_ty]
+in
+let code_lambda =
+  annon_function "args" param_storage_ty
+    ~body:(
+      let_tuple_in
+        [(var "p"); (var "s")]
+        ~rhs:(variable (var "args") param_storage_ty)
+        ~in_:
+          (let_in (var "x") ~rhs:(nat 1)
+            ~in_:
+              (let new_s = add (variable (var "x") nat_ty) (nat 2) in
+              (* returns (nil operation, new_s) *)
+              tuple (mk_row [
+                Leaf (None, nil (operation_ty));
+                Leaf (None, new_s)
+              ])))
+    )
+in
+let expr =
+  create_contract
+    ~storage:storage_ty
+    ~code:code_lambda
+    ~delegate:(none key_hash_ty)
+    ~initial_balance:(mutez 1000)
+    ~initial_storage:(nat 10)
+in
+test_expr expr;
+[%expect {|
+  { PUSH nat 10 ;
+    PUSH mutez 1000 ;
+    NONE key_hash ;
+    CREATE_CONTRACT
+      { parameter nat ;
+        storage nat ;
+        code { UNPAIR ;
+               DROP ;
+               DROP ;
+               PUSH nat 1 ;
+               PUSH nat 2 ;
+               SWAP ;
+               ADD ;
+               NIL operation ;
+               PAIR } } ;
+    PAIR }
+  
+  Optimised:
+  { PUSH nat 10 ;
+    PUSH mutez 1000 ;
+    NONE key_hash ;
+    CREATE_CONTRACT
+      { parameter nat ;
+        storage nat ;
+        code { DROP ; PUSH nat 1 ; PUSH nat 2 ; ADD ; NIL operation ; PAIR } } ;
+    PAIR } |}]
+
+(* ARITY 0 PRIMITIVES *)
+
+let%expect_test "amount basic" =
+  let e = amount in
+  test_expr e;
+  [%expect {|
+    { AMOUNT }
+
+    Optimised:
+    { AMOUNT } |}]
+
+let%expect_test "balance basic" =
+  let e = balance in
+  test_expr e;
+  [%expect {|
+    { BALANCE }
+
+    Optimised:
+    { BALANCE } |}]
+
+let%expect_test "chain_id basic" =
+  let e = chain_id_prim in
+  test_expr e;
+  [%expect {|
+    { CHAIN_ID }
+
+    Optimised:
+    { CHAIN_ID } |}]
+
+let%expect_test "level basic" =
+  let e = level in
+  test_expr e;
+  [%expect {|
+    { LEVEL }
+
+    Optimised:
+    { LEVEL } |}]
+
+let%expect_test "now basic" =
+  let e = now in
+  test_expr e;
+  [%expect {|
+    { NOW }
+
+    Optimised:
+    { NOW } |}]
+
+let%expect_test "self without entrypoint" =
+  let contract_type = contract_ty unit_ty in
+  let e = self None contract_type in
+  test_expr e;
+  [%expect {|
+    { SELF }
+
+    Optimised:
+    { SELF } |}]
+
+let%expect_test "self with entrypoint" =
+  let contract_type = contract_ty nat_ty in
+  let e = self (Some ("%test_entry")) contract_type in
+  test_expr e;
+  [%expect {|
+    { SELF %test_entry }
+
+    Optimised:
+    { SELF %test_entry } |}]
+
+let%expect_test "self_address basic" =
+  let e = self_address in
+  test_expr e;
+  [%expect {|
+    { SELF_ADDRESS }
+
+    Optimised:
+    { SELF_ADDRESS } |}]
+
+let%expect_test "sender basic" =
+  let e = sender in
+  test_expr e;
+  [%expect {|
+    { SENDER }
+
+    Optimised:
+    { SENDER } |}]
+
+let%expect_test "source basic" =
+  let e = source in
+  test_expr e;
+  [%expect {|
+    { SOURCE }
+
+    Optimised:
+    { SOURCE } |}]
+
+let%expect_test "total_voting_power basic" =
+  let e = total_voting_power in
+  test_expr e;
+  [%expect {|
+    { TOTAL_VOTING_POWER }
+
+    Optimised:
+    { TOTAL_VOTING_POWER } |}]
+
+let%expect_test "empty_bigmap nat->int" =
+  let e = empty_bigmap nat_ty int_ty in
+  test_expr e;
+  [%expect {|
+    { EMPTY_BIG_MAP nat int }
+
+    Optimised:
+    { EMPTY_BIG_MAP nat int } |}]
+
+let%expect_test "empty_map string->bool" =
+  let e = empty_map string_ty bool_ty in
+  test_expr e;
+  [%expect {|
+    { EMPTY_MAP string bool }
+
+    Optimised:
+    { EMPTY_MAP string bool } |}]
+
+let%expect_test "empty_set address" =
+  let e = empty_set address_ty in
+  test_expr e;
+  [%expect {|
+    { EMPTY_SET address }
+
+    Optimised:
+    { EMPTY_SET address } |}]
+
+let%expect_test "nil int" =
+  let e = nil int_ty in
+  test_expr e;
+  [%expect {|
+    { NIL int }
+
+    Optimised:
+    { NIL int } |}]
+
+let%expect_test "none bool" =
+  let e = none bool_ty in
+  test_expr e;
+  [%expect {|
+    { NONE bool }
+
+    Optimised:
+    { NONE bool } |}]
+
+let%expect_test "sapling_empty_state memo8" =
+  let e = sapling_empty_state 8  in
+  test_expr e;
+  [%expect {|
+    { SAPLING_EMPTY_STATE 8 }
+
+    Optimised:
+    { SAPLING_EMPTY_STATE 8 }
+    ms: 8
+    ms: 8 |}]
+
+let%expect_test "unit prim" =
+  let e = unit_prim in
+  test_expr e;
+  [%expect {|
+    { UNIT }
+
+    Optimised:
+    { UNIT } |}]
+
+(* ARITY 1/2 PRIMITIVES *)
+
+let%expect_test "car on pair" =
+  let pair_expr = pair (None,None) (int 1) (int 2) in
+  let e = car pair_expr in
+  test_expr e;
+  [%expect {|
+    { PUSH int 2 ; PUSH int 1 ; PAIR ; CAR }
+
+    Optimised:
+    { PUSH int 1 } |}]
+
+let%expect_test "cdr on pair" =
+  let pair_expr = pair (None,None) (int 1) (int 2) in
+  let e = cdr pair_expr in
+  test_expr e;
+  [%expect {|
+    { PUSH int 2 ; PUSH int 1 ; PAIR ; CDR }
+
+    Optimised:
+    { PUSH int 2 } |}]
+
+let%expect_test "left constructor" =
+  let e = left (None,None, string_ty) (int 42) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 42 ; LEFT string }
+
+    Optimised:
+    { PUSH int 42 ; LEFT string } |}]
+
+let%expect_test "right constructor" =
+  let e = right (None,None, bool_ty) (string "test") in
+  test_expr e;
+  [%expect {|
+    { PUSH string "test" ; RIGHT bool }
+
+    Optimised:
+    { PUSH string "test" ; RIGHT bool } |}]
+
+let%expect_test "some constructor" =
+  let e = some (nat 999) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 999 ; SOME }
+
+    Optimised:
+    { PUSH nat 999 ; SOME } |}]
+
+let%expect_test "abs on negative int" =
+  let e = abs (int (-42)) in
+  test_expr e;
+  [%expect {|
+    { PUSH int -42 ; ABS }
+
+    Optimised:
+    { PUSH int -42 ; ABS } |}]
+
+let%expect_test "neg on nat (coerced to int)" =
+  let e = neg (nat 10) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 10 ; NEG }
+
+    Optimised:
+    { PUSH int -10 } |}]
+
+let%expect_test "nat_prim from int" =
+  let e = nat_prim (int 50) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 50 ; NAT }
+
+    Optimised:
+    { PUSH int 50 ; NAT } |}]
+
+let%expect_test "int_prim from nat" =
+  let e = int_prim (nat 123) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 123 ; INT }
+
+    Optimised:
+    { PUSH nat 123 ; INT } |}]
+
+let%expect_test "bytes_prim from string" =
+  let e = bytes_prim (string "raw") in
+  test_expr e;
+  [%expect {|
+    { PUSH string "raw" ; BYTES }
+
+    Optimised:
+    { PUSH string "raw" ; BYTES } |}]
+
+let%expect_test "is_nat with negative int" =
+  let e = is_nat (int (-100)) in
+  test_expr e;
+  [%expect {|
+    { PUSH int -100 ; ISNAT }
+
+    Optimised:
+    { PUSH int -100 ; ISNAT } |}]
+
+let%expect_test "compare eq int" =
+  let e = eq (int 2) (int 2) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 2 ; PUSH int 2 ; COMPARE ; EQ }
+
+    Optimised:
+    { PUSH bool True } |}]
+
+let%expect_test "compare neq string" =
+  let e = neq (string "hello") (string "world") in
+  test_expr e;
+  [%expect {|
+    { PUSH string "world" ; PUSH string "hello" ; COMPARE ; NEQ }
+
+    Optimised:
+    { PUSH string "world" ; PUSH string "hello" ; COMPARE ; NEQ } |}]
+
+let%expect_test "compare lt nat" =
+  let e = lt (nat 5) (nat 10) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 10 ; PUSH nat 5 ; COMPARE ; LT }
+
+    Optimised:
+    { PUSH bool True } |}]
+
+let%expect_test "compare gt int" =
+  let e = gt (int 10) (int 3) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 3 ; PUSH int 10 ; COMPARE ; GT }
+
+    Optimised:
+    { PUSH bool True } |}]
+
+let%expect_test "compare le int" =
+  let e = le (int 1) (int 1) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 1 ; PUSH int 1 ; COMPARE ; LE }
+
+    Optimised:
+    { PUSH int 0 ; LE } |}]
+
+let%expect_test "compare ge string" =
+  let e = ge (string "a") (string "b") in
+  test_expr e;
+  [%expect {|
+    { PUSH string "b" ; PUSH string "a" ; COMPARE ; GE }
+
+    Optimised:
+    { PUSH string "b" ; PUSH string "a" ; COMPARE ; GE } |}]
+
+let%expect_test "not bool" =
+  let e = not (bool false) in
+  test_expr e;
+  [%expect {|
+    { PUSH bool False ; NOT }
+
+    Optimised:
+    { PUSH bool True } |}]
+
+let%expect_test "not int" =
+  let e = not (int 123) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 123 ; NOT }
+
+    Optimised:
+    { PUSH int 123 ; NOT } |}]
+
+let%expect_test "size on bytes" =
+  let e = size (bytes "0xABCDEF") in
+  test_expr e;
+  [%expect {|
+    { PUSH bytes 0x3078414243444546 ; SIZE }
+
+    Optimised:
+    { PUSH bytes 0x3078414243444546 ; SIZE } |}]
+
+let%expect_test "address of contract" =
+  let contract_expr = self None (contract_ty unit_ty) in
+  let e = address contract_expr in
+  test_expr e;
+  [%expect {|
+    { SELF ; ADDRESS }
+
+    Optimised:
+    { SELF_ADDRESS } |}]
+
+let%expect_test "implicit_account key_hash" =
+  let e = implicit_account (key_hash "tz1ABC123") in
+  test_expr e;
+  [%expect {|
+    { PUSH key_hash "tz1ABC123" ; IMPLICIT_ACCOUNT }
+
+    Optimised:
+    { PUSH key_hash "tz1ABC123" ; IMPLICIT_ACCOUNT } |}]
+
+let%expect_test "contract opt (bool_ty) address" =
+  let e = contract (None, bool_ty) (address_const "KT1XYZ") in
+  test_expr e;
+  [%expect {|
+    { PUSH address "KT1XYZ" ; CONTRACT bool }
+
+    Optimised:
+    { PUSH address "KT1XYZ" ; CONTRACT bool } |}]
+
+let%expect_test "pack int" =
+  let e = pack (int (-7)) in
+  test_expr e;
+  [%expect {|
+    { PUSH int -7 ; PACK }
+
+    Optimised:
+    { PUSH int -7 ; PACK } |}]
+
+let%expect_test "unpack string" =
+  let e = unpack string_ty (bytes "0xDEADBEEF") in
+  test_expr e;
+  [%expect {|
+    { PUSH bytes 0x30784445414442454546 ; UNPACK string }
+
+    Optimised:
+    { PUSH bytes 0x30784445414442454546 ; UNPACK string } |}]
+
+let%expect_test "hash_key key" =
+  let e = hash_key (key "edpkExampleKey") in
+  test_expr e;
+  [%expect {|
+    { PUSH key "edpkExampleKey" ; HASH_KEY }
+
+    Optimised:
+    { PUSH key "edpkExampleKey" ; HASH_KEY } |}]
+
+let%expect_test "blake2b bytes" =
+  let e = blake2b (bytes "0xAB12") in
+  test_expr e;
+  [%expect {|
+    { PUSH bytes 0x307841423132 ; BLAKE2B }
+
+    Optimised:
+    { PUSH bytes 0x307841423132 ; BLAKE2B } |}]
+
+let%expect_test "sha256 bytes" =
+  let e = sha256 (bytes "0xAB12") in
+  test_expr e;
+  [%expect {|
+    { PUSH bytes 0x307841423132 ; SHA256 }
+
+    Optimised:
+    { PUSH bytes 0x307841423132 ; SHA256 } |}]
+
+let%expect_test "sha512 bytes" =
+  let e = sha512 (bytes "0xAB12") in
+  test_expr e;
+  [%expect {|
+    { PUSH bytes 0x307841423132 ; SHA512 }
+
+    Optimised:
+    { PUSH bytes 0x307841423132 ; SHA512 } |}]
+
+let%expect_test "keccak bytes" =
+  let e = keccak (bytes "0xAB12") in
+  test_expr e;
+  [%expect {|
+    { PUSH bytes 0x307841423132 ; KECCAK }
+
+    Optimised:
+    { PUSH bytes 0x307841423132 ; KECCAK } |}]
+
+let%expect_test "sha3 bytes" =
+  let e = sha3 (bytes "0xAB12") in
+  test_expr e;
+  [%expect {|
+    { PUSH bytes 0x307841423132 ; SHA3 }
+
+    Optimised:
+    { PUSH bytes 0x307841423132 ; SHA3 } |}]
+
+let%expect_test "set_delegate none" =
+  let e = set_delegate (none key_hash_ty) in
+  test_expr e;
+  [%expect {|
+    { NONE key_hash ; SET_DELEGATE }
+
+    Optimised:
+    { NONE key_hash ; SET_DELEGATE } |}]
+
+let%expect_test "read_ticket ticket" =
+  let unwrap_ticket =
+    if_none (ticket (string "T") (nat 5))
+      ~none:(failwith (string "No ticket"))
+      ~some:{
+        lam_var = (var "tk", ticket_ty string_ty);
+        body = variable (var "tk") (ticket_ty string_ty)
+      }
+  in
+  let e = read_ticket unwrap_ticket in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 5 ;
+      PUSH string "T" ;
+      TICKET ;
+      IF_NONE { PUSH string "No ticket" ; FAILWITH } {} ;
+      { READ_TICKET ; PAIR } }
+
+    Optimised:
+    { PUSH nat 5 ;
+      PUSH string "T" ;
+      TICKET ;
+      IF_NONE { PUSH string "No ticket" ; FAILWITH } {} ;
+      READ_TICKET ;
+      PAIR } |}]
+
+let%expect_test "join_tickets same type" =
+  let t1_opt = ticket (string "C1") (nat 2) in
+  let t2_opt = ticket (string "C1") (nat 3) in
+  let unwrap opt_e var_name =
+    if_none opt_e
+      ~none:(failwith (string "no ticket"))
+      ~some:{
+        lam_var = (var var_name, ticket_ty string_ty);
+        body = variable (var var_name) (ticket_ty string_ty)
+      }
+  in
+  let t1 = unwrap t1_opt "tk1" in
+  let t2 = unwrap t2_opt "tk2" in
+  let e = join_tickets t1 t2 in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 3 ;
+      PUSH string "C1" ;
+      TICKET ;
+      IF_NONE { PUSH string "no ticket" ; FAILWITH } {} ;
+      PUSH nat 2 ;
+      PUSH string "C1" ;
+      TICKET ;
+      IF_NONE { PUSH string "no ticket" ; FAILWITH } {} ;
+      JOIN_TICKETS }
+
+    Optimised:
+    { PUSH nat 3 ;
+      PUSH string "C1" ;
+      TICKET ;
+      IF_NONE { PUSH string "no ticket" ; FAILWITH } {} ;
+      PUSH nat 2 ;
+      PUSH string "C1" ;
+      TICKET ;
+      IF_NONE { PUSH string "no ticket" ; FAILWITH } {} ;
+      JOIN_TICKETS } |}]
+
+let%expect_test "pairing_check bls12 list" =
+  let g1 = bls12_381_g1 "G1" in
+  let g2 = bls12_381_g2 "G2" in
+  let pair_expr = pair (None,None) g1 g2 in
+  let list_expr = cons pair_expr (nil (mk_tuple_ty [bls12_381_g1_ty; bls12_381_g2_ty])) in
+  let e = pairing_check list_expr in
+  test_expr e;
+  [%expect {|
+    { NIL (pair bls12_381_g1 bls12_381_g2) ;
+      PUSH bls12_381_g2 0x4732 ;
+      PUSH bls12_381_g1 0x4731 ;
+      PAIR ;
+      CONS ;
+      PAIRING_CHECK }
+
+    Optimised:
+    { PUSH (list (pair bls12_381_g1 bls12_381_g2)) { Pair 0x4731 0x4732 } ;
+      PAIRING_CHECK } |}]
+
+let%expect_test "voting_power key_hash" =
+  let e = voting_power (key_hash "tz1Example") in
+  test_expr e;
+  [%expect {|
+    { PUSH key_hash "tz1Example" ; VOTING_POWER }
+
+    Optimised:
+    { PUSH key_hash "tz1Example" ; VOTING_POWER } |}]
+
+(*let%expect_test "getn usage" =
+  (* Commented out as getn is not implemented *)
+  let triple = tuple (mk_row [
+    Leaf (None, nat 1);
+    Leaf (None, int (-1));
+    Leaf (None, bool true)
+  ]) in
+  let expr = getn 2 triple in
+  test_expr expr;
+  [%expect {||}]*)
+
+let%expect_test "cast from int to int" =
+  let e = cast int_ty (int 42) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 42 ; CAST int }
+
+    Optimised:
+    { PUSH int 42 ; CAST int } |}]
+
+let%expect_test "cast from nat to int" =
+  let e = cast int_ty (nat 999) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 999 ; CAST int }
+
+    Optimised:
+    { PUSH nat 999 ; CAST int } |}]
+
+let%expect_test "cast from bool to bool" =
+  let e = cast bool_ty (bool true) in
+  test_expr e;
+  [%expect {|
+    { PUSH bool True ; CAST bool }
+
+    Optimised:
+    { PUSH bool True ; CAST bool } |}]
+
+let%expect_test "emit basic" =
+  let e = emit (None, None) (string "Event data") in
+  test_expr e;
+  [%expect {|
+    { PUSH string "Event data" ; EMIT }
+
+    Optimised:
+    { PUSH string "Event data" ; EMIT } |}]
+
+let%expect_test "emit with no annotation" =
+  let e = emit (None,  Some(string_ty)) (string "Event data") in
+  test_expr e;
+  [%expect {|
+    { PUSH string "Event data" ; EMIT string }
+
+    Optimised:
+    { PUSH string "Event data" ; EMIT string } |}]
+
+let%expect_test "emit with no data" =
+  let e = emit (Some "LabelX", None) (string "Data2") in
+  test_expr e;
+  [%expect {|
+    { PUSH string "Data2" ; EMIT LabelX }
+
+    Optimised:
+    { PUSH string "Data2" ; EMIT LabelX } |}]
+
+let%expect_test "emit with label" =
+  let e = emit (Some "LabelX", Some(string_ty)) (string "Data2") in
+  test_expr e;
+  [%expect {|
+    { PUSH string "Data2" ; EMIT LabelX string }
+
+    Optimised:
+    { PUSH string "Data2" ; EMIT LabelX string } |}]
+
+let%expect_test "failwith basic" =
+  let e = failwith (string "Something went wrong") in
+  test_expr e;
+  [%expect {|
+    { PUSH string "Something went wrong" ; FAILWITH }
+
+    Optimised:
+    { PUSH string "Something went wrong" ; FAILWITH } |}]
+
+let%expect_test "never basic" =
+  let e = never (int 100) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 100 ; NEVER }
+
+    Optimised:
+    { PUSH int 100 ; NEVER } |}]
+
+let%expect_test "pair simple" =
+  let e = pair (None, None) (int 1) (int 2) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 2 ; PUSH int 1 ; PAIR }
+
+    Optimised:
+    { PUSH int 2 ; PUSH int 1 ; PAIR } |}]
+
+let%expect_test "pair with annotation" =
+  let e = pair (Some "fst", Some "snd") (string "hi") (bool false) in
+  test_expr e;
+  [%expect {|
+    { PUSH bool False ; PUSH string "hi" ; PAIR fst snd }
+
+    Optimised:
+    { PUSH bool False ; PUSH string "hi" ; PAIR } |}]
+
+let%expect_test "add nat nat" =
+  let e = add (nat 3) (nat 5) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 5 ; PUSH nat 3 ; ADD }
+
+    Optimised:
+    { PUSH nat 5 ; PUSH nat 3 ; ADD } |}]
+
+let%expect_test "add int nat" =
+  let e = add (int (-2)) (nat 7) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 7 ; PUSH int -2 ; ADD }
+
+    Optimised:
+    { PUSH nat 7 ; PUSH int -2 ; ADD } |}]
+
+let%expect_test "add timestamp int" =
+  let e = add (timestamp "2023-01-01T00:00:00Z") (int 60) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 60 ; PUSH timestamp 1672531200 ; ADD }
+
+    Optimised:
+    { PUSH int 60 ; PUSH timestamp 1672531200 ; ADD } |}]
+
+let%expect_test "mul nat nat" =
+  let e = mul (nat 2) (nat 10) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 10 ; PUSH nat 2 ; MUL }
+
+    Optimised:
+    { PUSH nat 10 ; PUSH nat 2 ; MUL } |}]
+
+let%expect_test "mul int nat" =
+  let e = mul (int 3) (nat 10) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 10 ; PUSH int 3 ; MUL }
+
+    Optimised:
+    { PUSH nat 10 ; PUSH int 3 ; MUL } |}]
+
+let%expect_test "mul mutez nat" =
+  let e = mul (mutez 1000) (nat 2) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 2 ; PUSH mutez 1000 ; MUL }
+
+    Optimised:
+    { PUSH nat 2 ; PUSH mutez 1000 ; MUL } |}]
+
+let%expect_test "sub int int" =
+  let e = sub (int 5) (int 10) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 10 ; PUSH int 5 ; SUB }
+
+    Optimised:
+    { PUSH int -5 } |}]
+
+let%expect_test "sub nat nat" =
+  let e = sub (nat 10) (nat 3) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 3 ; PUSH nat 10 ; SUB }
+
+    Optimised:
+    { PUSH nat 3 ; PUSH nat 10 ; SUB } |}]
+
+let%expect_test "sub timestamp int" =
+  let e = sub (timestamp "2023-01-01T00:00:00Z") (int 3600) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 3600 ; PUSH timestamp 1672531200 ; SUB }
+
+    Optimised:
+    { PUSH int 3600 ; PUSH timestamp 1672531200 ; SUB } |}]
+
+let%expect_test "sub mutez" =
+  let e = sub (mutez 2000) (mutez 500) in
+  test_expr e;
+  [%expect {|
+    { PUSH mutez 500 ; PUSH mutez 2000 ; SUB_MUTEZ }
+
+    Optimised:
+    { PUSH mutez 500 ; PUSH mutez 2000 ; SUB_MUTEZ } |}]
+
+let%expect_test "sub_mutez direct" =
+  let e = sub_mutez (mutez 2000) (mutez 1999) in
+  test_expr e;
+  [%expect {|
+    { PUSH mutez 1999 ; PUSH mutez 2000 ; SUB_MUTEZ }
+
+    Optimised:
+    { PUSH mutez 1999 ; PUSH mutez 2000 ; SUB_MUTEZ } |}]
+
+let%expect_test "lsr nat" =
+  let e = lsr_ (nat 16) (nat 1) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 1 ; PUSH nat 16 ; LSR }
+
+    Optimised:
+    { PUSH nat 1 ; PUSH nat 16 ; LSR } |}]
+
+let%expect_test "lsl nat" =
+  let e = lsl_ (nat 4) (nat 2) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 2 ; PUSH nat 4 ; LSL }
+
+    Optimised:
+    { PUSH nat 2 ; PUSH nat 4 ; LSL } |}]
+
+let%expect_test "xor on nat" =
+  let e = xor (nat 0b1010) (nat 0b0011) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 3 ; PUSH nat 10 ; XOR }
+
+    Optimised:
+    { PUSH nat 3 ; PUSH nat 10 ; XOR } |}]
+
+let%expect_test "ediv nat nat" =
+  let e = ediv (nat 10) (nat 3) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 3 ; PUSH nat 10 ; EDIV }
+
+    Optimised:
+    { PUSH nat 3 ; PUSH nat 10 ; EDIV } |}]
+
+let%expect_test "ediv mutez nat" =
+  let e = ediv (mutez 1000) (nat 10) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 10 ; PUSH mutez 1000 ; EDIV }
+
+    Optimised:
+    { PUSH nat 10 ; PUSH mutez 1000 ; EDIV } |}]
+
+let%expect_test "div_ with if_none" =
+  let e = div_ (int 10) (int 0) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 0 ;
+      PUSH int 10 ;
+      EDIV ;
+      IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } }
+
+    Optimised:
+    { PUSH int 0 ;
+      PUSH int 10 ;
+      EDIV ;
+      IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } } |}]
+
+let%expect_test "mod_ with if_none" =
+  let e = mod_ (nat 9) (nat 0) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 0 ;
+      PUSH nat 9 ;
+      EDIV ;
+      IF_NONE { PUSH string "MOD by 0" ; FAILWITH } { CDR } }
+
+    Optimised:
+    { PUSH nat 0 ;
+      PUSH nat 9 ;
+      EDIV ;
+      IF_NONE { PUSH string "MOD by 0" ; FAILWITH } { CDR } } |}]
+
+let%expect_test "and_ bool bool" =
+  let e = and_ (bool true) (bool false) in
+  test_expr e;
+  [%expect {|
+    { PUSH bool False ; PUSH bool True ; AND }
+
+    Optimised:
+    { PUSH bool False } |}]
+
+let%expect_test "and_ int int" =
+  let e = and_ (int 0xF0) (int 0xCC) in
+  test_expr e;
+  [%expect {|
+    { PUSH int 204 ; PUSH int 240 ; AND }
+
+    Optimised:
+    { PUSH int 204 ; PUSH int 240 ; AND } |}]
+
+let%expect_test "or_ bool bool" =
+  let e = or_ (bool false) (bool false) in
+  test_expr e;
+  [%expect {|
+    { PUSH bool False ; PUSH bool False ; OR }
+
+    Optimised:
+    { PUSH bool False } |}]
+
+let%expect_test "or_ nat nat" =
+  let e = or_ (nat 0b1010) (nat 0b0101) in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 5 ; PUSH nat 10 ; OR }
+
+    Optimised:
+    { PUSH nat 5 ; PUSH nat 10 ; OR } |}]
+
+let%expect_test "cons to list" =
+  let tail_list = cons (int 2) (cons (int 3) (nil int_ty)) in
+  let e = cons (int 1) tail_list in
+  test_expr e;
+  [%expect {|
+    { NIL int ; PUSH int 3 ; CONS ; PUSH int 2 ; CONS ; PUSH int 1 ; CONS }
+
+    Optimised:
+    { PUSH (list int) { 1 ; 2 ; 3 } } |}]
+
+let%expect_test "concat1 strings" =
+  let e = concat1 (string "Hello, ") (string "World!") in
+  test_expr e;
+  [%expect {|
+    { PUSH string "World!" ; PUSH string "Hello, " ; CONCAT }
+
+    Optimised:
+    { PUSH string "World!" ; PUSH string "Hello, " ; CONCAT } |}]
+
+let%expect_test "concat2 bytes" =
+  let e = concat2 (bytes "0xABCD") (bytes "0x1234") in
+  test_expr e;
+  [%expect {|
+    { NIL bytes ;
+      PUSH bytes 0x307831323334 ;
+      CONS ;
+      PUSH bytes 0x307841424344 ;
+      CONS ;
+      CONCAT }
+
+    Optimised:
+    { PUSH (list bytes) { 0x307841424344 ; 0x307831323334 } ; CONCAT } |}]
+
+let%expect_test "get from map" =
+  let m = empty_map nat_ty bool_ty in
+  let expr = get (nat 10) m in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_MAP nat bool ; PUSH nat 10 ; GET }
+
+    Optimised:
+    { EMPTY_MAP nat bool ; PUSH nat 10 ; GET } |}]
+
+let%expect_test "get from big_map" =
+  let bm = empty_bigmap string_ty int_ty in
+  let expr = get (string "hello") bm in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_BIG_MAP string int ; PUSH string "hello" ; GET }
+
+    Optimised:
+    { EMPTY_BIG_MAP string int ; PUSH string "hello" ; GET } |}]
+
+let%expect_test "mem in map" =
+  let m = empty_map nat_ty bool_ty in
+  let expr = mem (nat 999) m in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_MAP nat bool ; PUSH nat 999 ; MEM }
+
+    Optimised:
+    { EMPTY_MAP nat bool ; PUSH nat 999 ; MEM } |}]
+
+let%expect_test "mem in big_map" =
+  let bm = empty_bigmap nat_ty address_ty in
+  let expr = mem (nat 5) bm in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_BIG_MAP nat address ; PUSH nat 5 ; MEM }
+
+    Optimised:
+    { EMPTY_BIG_MAP nat address ; PUSH nat 5 ; MEM } |}]
+
+let%expect_test "mem in set" =
+  let s = empty_set int_ty in
+  let expr = mem (int 42) s in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_SET int ; PUSH int 42 ; MEM }
+
+    Optimised:
+    { EMPTY_SET int ; PUSH int 42 ; MEM } |}]
+
+let%expect_test "exec function" =
+  let lam = lambda (var "x", nat_ty) ~body:(add (variable (var "x") nat_ty) (nat 1)) in
+  let expr = exec (nat 10) lam in
+  test_expr expr;
+  [%expect {|
+    { LAMBDA nat nat { PUSH nat 1 ; SWAP ; ADD } ; PUSH nat 10 ; EXEC }
+
+    Optimised:
+    { LAMBDA nat nat { PUSH nat 1 ; ADD } ; PUSH nat 10 ; EXEC } |}]
+
+let%expect_test "apply partial function" =
+  let two_arg_fun =
+    lambda (var "pair", mk_tuple_ty [int_ty; int_ty])
+      ~body:(add
+               (car (variable (var "pair") (mk_tuple_ty [int_ty; int_ty])))
+               (cdr (variable (var "pair") (mk_tuple_ty [int_ty; int_ty]))))
+  in
+  let partial_applied = apply (int 5) two_arg_fun in
+  (* partial_applied should have type (int -> int) *)
+  let final_expr = exec (int 7) partial_applied in
+  test_expr final_expr;
+  [%expect {|
+    { LAMBDA (pair int int) int { DUP 1 ; CDR ; SWAP ; CAR ; ADD } ;
+      PUSH int 5 ;
+      APPLY ;
+      PUSH int 7 ;
+      EXEC }
+
+    Optimised:
+    { LAMBDA (pair int int) int { UNPAIR ; ADD } ;
+      PUSH int 5 ;
+      APPLY ;
+      PUSH int 7 ;
+      EXEC } |}]
+
+let%expect_test "sapling_verify_update correct types" =
+  let transaction =
+    (* For demonstration, we create a dummy expr with type Sapling_transaction 8. *)
+    cast (sapling_transaction_ty 8)
+      (bytes "0xDEADBEEF") 
+    (* This is simplistic; real code would produce an actual sapling tx. *)
+  in
+  let state =
+    sapling_empty_state 8
+  in
+  let expr = sapling_verify_update transaction state in
+  test_expr expr;
+  [%expect {|
+    { SAPLING_EMPTY_STATE 8 ;
+      PUSH bytes 0x30784445414442454546 ;
+      CAST (sapling_transaction 8) ;
+      SAPLING_VERIFY_UPDATE }
+
+    Optimised:
+    { SAPLING_EMPTY_STATE 8 ;
+      PUSH bytes 0x30784445414442454546 ;
+      CAST (sapling_transaction 8) ;
+      SAPLING_VERIFY_UPDATE }
+    ms: 8
+    ms: 8 |}]
+
+let%expect_test "ticket creation" =
+  let expr = ticket (string "TicketContent") (nat 3) in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 3 ; PUSH string "TicketContent" ; TICKET }
+
+    Optimised:
+    { PUSH nat 3 ; PUSH string "TicketContent" ; TICKET } |}]
+
+let%expect_test "ticket_deprecated usage" =
+  let expr = ticket_deprecated (int 42) (nat 2) in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 2 ; PUSH int 42 ; TICKET_DEPRECATED }
+
+    Optimised:
+    { PUSH nat 2 ; PUSH int 42 ; TICKET_DEPRECATED } |}]
+
+let%expect_test "ticket then read_ticket" =
+  let maybe_ticket = ticket (string "content") (nat 10) in
+  let unwrapped =
+    if_none maybe_ticket
+      ~none:(failwith (string "No ticket"))
+      ~some:{
+        lam_var = (var "tk", ticket_ty string_ty);
+        body = variable (var "tk") (ticket_ty string_ty)
+      }
+  in
+  let expr = read_ticket unwrapped in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 10 ;
+      PUSH string "content" ;
+      TICKET ;
+      IF_NONE { PUSH string "No ticket" ; FAILWITH } {} ;
+      { READ_TICKET ; PAIR } }
+
+    Optimised:
+    { PUSH nat 10 ;
+      PUSH string "content" ;
+      TICKET ;
+      IF_NONE { PUSH string "No ticket" ; FAILWITH } {} ;
+      READ_TICKET ;
+      PAIR } |}]
+
+let%expect_test "split_ticket usage" =
+  let maybe_ticket = ticket (nat 123) (nat 10) in
+  let unwrapped =
+    if_none maybe_ticket
+      ~none:(failwith (string "No ticket"))
+      ~some:{
+        lam_var = (var "tk", ticket_ty nat_ty);
+        body = variable (var "tk") (ticket_ty nat_ty)
+      }
+  in
+  let amounts = pair (None, None) (nat 3) (nat 7) in
+  let expr = split_ticket unwrapped amounts in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 7 ;
+      PUSH nat 3 ;
+      PAIR ;
+      PUSH nat 10 ;
+      PUSH nat 123 ;
+      TICKET ;
+      IF_NONE { PUSH string "No ticket" ; FAILWITH } {} ;
+      SPLIT_TICKET }
+
+    Optimised:
+    { PUSH nat 7 ;
+      PUSH nat 3 ;
+      PAIR ;
+      PUSH nat 10 ;
+      PUSH nat 123 ;
+      TICKET ;
+      IF_NONE { PUSH string "No ticket" ; FAILWITH } {} ;
+      SPLIT_TICKET } |}]
+
+(*
+  Commented out as updaten is not implemented.
+  let%expect_test "updaten usage" =
+  let pair_expr = pair (None,None) (int 5) (bool true) in
+  let expr = updaten 1 (string "replacement") pair_expr in
+  test_expr expr;
+  [%expect {||}]*)
+
+let%expect_test "view usage" =
+  let expr =
+    view
+      "myView"
+      ~return_type:nat_ty
+      ~d:(int 7)
+      ~address:(address_const "KT1SampleAddress")
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH address "KT1SampleAddress" ; PUSH int 7 ; VIEW "myView" nat }
+
+    Optimised:
+    { PUSH address "KT1SampleAddress" ; PUSH int 7 ; VIEW "myView" nat } |}]
+
+let%expect_test "slice on string" =
+  let off = nat 1 in
+  let len = nat 3 in
+  let s = string "Hello" in
+  let expr = slice off ~length:len ~seq:s in
+  test_expr expr;
+  [%expect {|
+    { PUSH string "Hello" ; PUSH nat 3 ; PUSH nat 1 ; SLICE }
+
+    Optimised:
+    { PUSH string "Hello" ; PUSH nat 3 ; PUSH nat 1 ; SLICE } |}]
+
+let%expect_test "slice on bytes" =
+  let off = nat 2 in
+  let len = nat 4 in
+  let b = bytes "0xDEADBEEF" in
+  let expr = slice off ~length:len ~seq:b in
+  test_expr expr;
+  [%expect {|
+    { PUSH bytes 0x30784445414442454546 ; PUSH nat 4 ; PUSH nat 2 ; SLICE }
+
+    Optimised:
+    { PUSH bytes 0x30784445414442454546 ; PUSH nat 4 ; PUSH nat 2 ; SLICE } |}]
+
+let%expect_test "update in a map" =
+  let m = empty_map nat_ty int_ty in
+  let expr = update (nat 7) (some (int 100)) ~of_:m in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_MAP nat int ; PUSH int 100 ; SOME ; PUSH nat 7 ; UPDATE }
+
+    Optimised:
+    { PUSH (map nat int) { Elt 7 100 } } |}]
+
+let%expect_test "update remove key in a map" =
+  let m = empty_map string_ty bool_ty in
+  let expr = update (string "test") (none bool_ty) ~of_:m in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_MAP string bool ; NONE bool ; PUSH string "test" ; UPDATE }
+
+    Optimised:
+    { EMPTY_MAP string bool ; NONE bool ; PUSH string "test" ; UPDATE } |}]
+
+let%expect_test "update in a set" =
+  let s = empty_set int_ty in
+  (* For sets, value is bool. True => add, False => remove. *)
+  let expr = update (int 3) (bool true) ~of_:s in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_SET int ; PUSH bool True ; PUSH int 3 ; UPDATE }
+
+    Optimised:
+    { PUSH (set int) { 3 } } |}]
+
+let%expect_test "get_and_update in map" =
+  let m = empty_map bool_ty nat_ty in
+  let expr = get_and_update (bool false) (some (nat 42)) ~of_:m in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_MAP bool nat ;
+      PUSH nat 42 ;
+      SOME ;
+      PUSH bool False ;
+      { GET_AND_UPDATE ; PAIR } }
+
+    Optimised:
+    { EMPTY_MAP bool nat ;
+      PUSH nat 42 ;
+      SOME ;
+      PUSH bool False ;
+      GET_AND_UPDATE ;
+      PAIR } |}]
+
+let%expect_test "get_and_update removing from big_map" =
+  let bm = empty_bigmap nat_ty string_ty in
+  let expr = get_and_update (nat 99) (none string_ty) ~of_:bm in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_BIG_MAP nat string ;
+      NONE string ;
+      PUSH nat 99 ;
+      { GET_AND_UPDATE ; PAIR } }
+
+    Optimised:
+    { EMPTY_BIG_MAP nat string ;
+      NONE string ;
+      PUSH nat 99 ;
+      GET_AND_UPDATE ;
+      PAIR } |}]
+
+let%expect_test "transfer_tokens simple" =
+  let param = unit in
+  let amt = mutez 1_000_000 in
+  let c = contract (None, unit_ty) (address_const "KT1Example") in
+  let expr = transfer_tokens param ~amount:amt ~contract:c in
+  test_expr expr;
+  [%expect {|
+    { PUSH address "KT1Example" ;
+      CONTRACT unit ;
+      PUSH mutez 1000000 ;
+      UNIT ;
+      TRANSFER_TOKENS }
+
+    Optimised:
+    { PUSH address "KT1Example" ;
+      CONTRACT unit ;
+      PUSH mutez 1000000 ;
+      UNIT ;
+      TRANSFER_TOKENS } |}]
+
+let%expect_test "check_signature usage" =
+  let k = key "edpkExample" in
+  let sig_ = signature "edsigExampleSig" in
+  let msg = bytes "0xDEADBEEF" in
+  let expr = check_signature k ~signature:sig_ ~message:msg in
+  test_expr expr;
+  [%expect {|
+    { PUSH bytes 0x30784445414442454546 ;
+      PUSH signature "edsigExampleSig" ;
+      PUSH key "edpkExample" ;
+      CHECK_SIGNATURE }
+
+    Optimised:
+    { PUSH bytes 0x30784445414442454546 ;
+      PUSH signature "edsigExampleSig" ;
+      PUSH key "edpkExample" ;
+      CHECK_SIGNATURE } |}]
+
+let%expect_test "open_chest usage" =
+  let chest_key_expr = bytes "0xAB" in
+  let chest_expr = bytes "0xCD" in
+  let time_expr = nat 100 in
+  let expr = open_chest chest_key_expr ~chest:chest_expr ~time:time_expr in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 100 ;
+      PUSH bytes 0x30784344 ;
+      PUSH bytes 0x30784142 ;
+      OPEN_CHEST }
+
+    Optimised:
+    { PUSH nat 100 ;
+      PUSH bytes 0x30784344 ;
+      PUSH bytes 0x30784142 ;
+      OPEN_CHEST } |}]
+
+let%expect_test "convert_list usage" =
+  let lst_exprs = [int 1; int 2; int 3] in
+  let row = convert_list lst_exprs in
+  let tuple_expr =
+    tuple (row)
+  in
+  test_expr tuple_expr;
+  [%expect {|
+    { PUSH int 3 ; PUSH int 2 ; PUSH int 1 ; PAIR 3 }
+
+    Optimised:
+    { PUSH int 3 ; PUSH int 2 ; PUSH int 1 ; PAIR 3 } |}]
+
+let%expect_test "gen_name usage" =
+  let x = gen_name in
+  let expr =
+    let_in (Var x) ~rhs:(nat 10)
+      ~in_:(variable (Var x) nat_ty)
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 10 }
+
+    Optimised:
+    { PUSH nat 10 } |}]
+
+let%expect_test "global_constant usage" =
+  let hash_val = "expruExampleHash" in
+  let args = [nat 42; bool false] in
+  let val_ty = int_ty in
+  let expr = global_constant hash_val args val_ty in
+  test_expr expr;
+  [%expect {|
+    { PUSH bool False ; PUSH nat 42 ; constant "expruExampleHash" }
+
+    Optimised:
+    { PUSH bool False ; PUSH nat 42 ; constant "expruExampleHash" } |}]
+
+let%expect_test "cast int->nat with negative int" =
+  let negative_int = int (-10) in
+  let expr = cast nat_ty negative_int in
+  test_expr expr;
+  [%expect {|
+    { PUSH int -10 ; CAST nat }
+
+    Optimised:
+    { PUSH int -10 ; CAST nat } |}]
+
+let%expect_test "lambda -> lambda -> lambda" =
+  let inner =
+    lambda (var "z", bool_ty)
+      ~body:(
+        if_bool (variable (var "z") bool_ty)
+          ~then_:(add (variable (var "x") int_ty) (variable (var "y") nat_ty))
+          ~else_:(sub (variable (var "x") int_ty) (variable (var "y") nat_ty))
+      )
+  in
+  let mid =
+    lambda (var "y", nat_ty)
+      ~body:inner
+  in
+  let outer =
+    lambda (var "x", int_ty)
+      ~body:mid
+  in
+  test_expr outer;
+  [%expect {|
+    { LAMBDA
+        int
+        (lambda nat (lambda bool int))
+        { LAMBDA
+            (pair int nat)
+            (lambda bool int)
+            { UNPAIR ;
+              LAMBDA
+                (pair int (pair nat bool))
+                int
+                { UNPAIR 3 ; DIG 2 ; IF { SWAP ; SWAP ; ADD } { SWAP ; SWAP ; SUB } } ;
+              SWAP ;
+              APPLY ;
+              SWAP ;
+              APPLY } ;
+          SWAP ;
+          APPLY } }
+
+    Optimised:
+    { LAMBDA
+        int
+        (lambda nat (lambda bool int))
+        { LAMBDA
+            (pair int nat)
+            (lambda bool int)
+            { UNPAIR ;
+              LAMBDA
+                (pair int (pair nat bool))
+                int
+                { UNPAIR 3 ; DIG 2 ; IF { ADD } { SUB } } ;
+              SWAP ;
+              APPLY ;
+              SWAP ;
+              APPLY } ;
+          SWAP ;
+          APPLY } } |}]
+
+let%expect_test "apply function with 3-tuple param" =
+  let three_tuple_ty =
+    mk_tuple_ty [int_ty; mk_tuple_ty [int_ty; int_ty]]
+  in
+  let three_tuple_fun =
+    lambda (var "p", three_tuple_ty)
+      ~body:(
+        add
+          (car (variable (var "p") three_tuple_ty))
+          (add
+             (car (cdr (variable (var "p") three_tuple_ty)))
+             (cdr (cdr (variable (var "p") three_tuple_ty))))
+      )
+  in
+  let partial_applied =
+    apply (int 2) three_tuple_fun
+  in
+  let final_expr =
+    exec
+      (tuple (mk_row [Leaf(None, int 3); Leaf(None, int 4)]))
+      partial_applied
+  in
+  test_expr final_expr;
+  [%expect{|
+    { LAMBDA
+        (pair int (pair int int))
+        int
+        { DUP 1 ; CDR ; CDR ; DUP 2 ; CDR ; CAR ; ADD ; SWAP ; CAR ; ADD } ;
+      PUSH int 2 ;
+      APPLY ;
+      PUSH int 4 ;
+      PUSH int 3 ;
+      PAIR ;
+      EXEC }
+
+    Optimised:
+    { LAMBDA
+        (pair int (pair int int))
+        int
+        { DUP ; GET 4 ; DUP 2 ; GET 3 ; ADD ; SWAP ; CAR ; ADD } ;
+      PUSH int 2 ;
+      APPLY ;
+      PUSH int 4 ;
+      PUSH int 3 ;
+      PAIR ;
+      EXEC } |}]
+
+let%expect_test "apply leftover function unused" =
+  let two_tuple_ty = mk_tuple_ty [nat_ty; nat_ty] in
+  let two_tuple_fun =
+    lambda (var "p", two_tuple_ty)
+      ~body:(
+        add
+          (car (variable (var "p") two_tuple_ty))
+          (cdr (variable (var "p") two_tuple_ty))
+      )
+  in
+  let partial_applied = apply (nat 8) two_tuple_fun in
+  test_expr partial_applied;
+  [%expect {|
+    { LAMBDA (pair nat nat) nat { DUP 1 ; CDR ; SWAP ; CAR ; ADD } ;
+      PUSH nat 8 ;
+      APPLY }
+
+    Optimised:
+    { LAMBDA (pair nat nat) nat { UNPAIR ; ADD } ; PUSH nat 8 ; APPLY } |}]
+
+let%expect_test "failwith usage in else branch" =
+  let condition = eq (string "ok") (string "fail") in
+  let expr =
+    if_bool condition
+      ~then_:(nat 1)
+      ~else_:(failwith (concat1 (string "Error: ") (string "String mismatch")))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH string "fail" ;
+      PUSH string "ok" ;
+      COMPARE ;
+      EQ ;
+      IF { PUSH nat 1 }
+         { PUSH string "String mismatch" ; PUSH string "Error: " ; CONCAT ; FAILWITH } }
+
+    Optimised:
+    { PUSH string "fail" ;
+      PUSH string "ok" ;
+      COMPARE ;
+      EQ ;
+      IF {}
+         { PUSH string "String mismatch" ; PUSH string "Error: " ; CONCAT ; FAILWITH } ;
+      PUSH nat 1 } |}]
+
+let%expect_test "update big_map of nat->contract(bool)" =
+  let bigm =
+    empty_bigmap nat_ty (contract_ty bool_ty)
+  in
+  let contr = some (contract (None, bool_ty) (address_const "KT1Test")) in
+  let expr = update (nat 10) contr ~of_:bigm in
+  test_expr expr;
+  [%expect {|
+    { EMPTY_BIG_MAP nat (contract bool) ;
+      PUSH address "KT1Test" ;
+      CONTRACT bool ;
+      SOME ;
+      PUSH nat 10 ;
+      UPDATE }
+
+    Optimised:
+    { EMPTY_BIG_MAP nat (contract bool) ;
+      PUSH address "KT1Test" ;
+      CONTRACT bool ;
+      SOME ;
+      PUSH nat 10 ;
+      UPDATE } |}]
+
+let%expect_test "chained cast" =
+  let e =
+    cast int_ty (
+      cast nat_ty (
+        cast int_ty (nat 99)
+      )
+    )
+  in
+  test_expr e;
+  [%expect {|
+    { PUSH nat 99 ; CAST int ; CAST nat ; CAST int }
+
+    Optimised:
+    { PUSH nat 99 ; CAST int ; CAST nat ; CAST int } |}]
+
+let%expect_test "global_constant returning function" =
+  let hash_val = "expruCustomHash" in
+  let args = [nat 2; int (-3)] in
+  let val_ty = function_ty nat_ty int_ty in
+  let expr = global_constant hash_val args val_ty in
+  test_expr expr;
+  [%expect {|
+    { PUSH int -3 ; PUSH nat 2 ; constant "expruCustomHash" }
+
+    Optimised:
+    { PUSH int -3 ; PUSH nat 2 ; constant "expruCustomHash" } |}]
+
+let%expect_test "apply global constant function" =
+  let val_ty = function_ty nat_ty int_ty in
+  let gc_expr = global_constant "expruFuncHash" [] val_ty in
+  let expr = app gc_expr (nat 100) in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 100 ;
+      LAMBDA nat int { constant "expruFuncHash" } ;
+      SWAP ;
+      EXEC }
+
+    Optimised:
+    { PUSH nat 100 ; constant "expruFuncHash" } |}]
+
+let%expect_test "lambda capturing external let var" =
+  let expr =
+    let_in (var "x") ~rhs:(nat 10)
+      ~in_:(
+        app
+          (lambda (var "y", nat_ty)
+             ~body:(add (variable (var "x") nat_ty) (variable (var "y") nat_ty)))
+          (nat 5)
+      )
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 10 ;
+      PUSH nat 5 ;
+      LAMBDA (pair nat nat) nat { UNPAIR ; SWAP ; SWAP ; ADD } ;
+      DIG 2 ;
+      APPLY ;
+      SWAP ;
+      EXEC }
+
+    Optimised:
+    { PUSH nat 10 ;
+      PUSH nat 5 ;
+      LAMBDA (pair nat nat) nat { UNPAIR ; ADD } ;
+      DIG 2 ;
+      APPLY ;
+      SWAP ;
+      EXEC } |}]
+
+let%expect_test "nested lambdas referencing outer variable" =
+  let expr =
+    let_in (var "a") ~rhs:(nat 2)
+      ~in_:
+        (let_in (var "b") ~rhs:(nat 3)
+          ~in_:
+            (lambda (var "x", nat_ty)
+              ~body:(
+                lambda (var "y", nat_ty)
+                  ~body:(
+                    add
+                      (add (variable (var "x") nat_ty) (variable (var "y") nat_ty))
+                      (add (variable (var "a") nat_ty) (variable (var "b") nat_ty))
+                  ))
+              ))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 2 ;
+      PUSH nat 3 ;
+      LAMBDA
+        (pair nat (pair nat nat))
+        (lambda nat nat)
+        { UNPAIR 3 ;
+          LAMBDA
+            (pair nat (pair nat (pair nat nat)))
+            nat
+            { UNPAIR 4 ; SWAP ; SWAP ; ADD ; DIG 2 ; DIG 2 ; ADD ; ADD } ;
+          SWAP ;
+          APPLY ;
+          SWAP ;
+          APPLY ;
+          SWAP ;
+          APPLY } ;
+      DIG 2 ;
+      APPLY ;
+      SWAP ;
+      APPLY }
+
+    Optimised:
+    { PUSH nat 2 ;
+      PUSH nat 3 ;
+      LAMBDA
+        (pair nat (pair nat nat))
+        (lambda nat nat)
+        { UNPAIR 3 ;
+          LAMBDA
+            (pair nat (pair nat (pair nat nat)))
+            nat
+            { UNPAIR 4 ; ADD ; DUG 2 ; ADD ; ADD } ;
+          SWAP ;
+          APPLY ;
+          SWAP ;
+          APPLY ;
+          SWAP ;
+          APPLY } ;
+      DIG 2 ;
+      APPLY ;
+      SWAP ;
+      APPLY } |}]
+
+let%expect_test "nested lambdas returning another referencing an external var" =
+  let expr =
+    let_in (var "factor") ~rhs:(nat 10)
+      ~in_:
+        (lambda (var "x", nat_ty)
+          ~body:(
+            lambda (var "y", nat_ty)
+              ~body:(
+                mul
+                  (mul (variable (var "x") nat_ty) (variable (var "y") nat_ty))
+                  (variable (var "factor") nat_ty)
+              )
+          ))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 10 ;
+      LAMBDA
+        (pair nat nat)
+        (lambda nat nat)
+        { UNPAIR ;
+          LAMBDA (pair nat (pair nat nat)) nat { UNPAIR 3 ; DIG 2 ; DIG 2 ; MUL ; MUL } ;
+          SWAP ;
+          APPLY ;
+          SWAP ;
+          APPLY } ;
+      SWAP ;
+      APPLY }
+
+    Optimised:
+    { LAMBDA
+        (pair nat nat)
+        (lambda nat nat)
+        { UNPAIR ;
+          LAMBDA (pair nat (pair nat nat)) nat { UNPAIR 3 ; DUG 2 ; MUL ; MUL } ;
+          SWAP ;
+          APPLY ;
+          SWAP ;
+          APPLY } ;
+      PUSH nat 10 ;
+      APPLY } |}]
+
+let%expect_test "partial application capturing environment" =
+  let pair_ty = mk_tuple_ty [nat_ty; nat_ty] in
+  let lam_f =
+    lambda (var "p", pair_ty)
+      ~body:(
+        add
+          (variable (var "a") nat_ty)
+          (add
+             (car (variable (var "p") pair_ty))
+             (cdr (variable (var "p") pair_ty)))
+      )
+  in
+  let expr =
+    let_in (var "a") ~rhs:(nat 42)
+      ~in_:
+        (let_in (var "f") ~rhs:lam_f
+          ~in_:
+            (let_in (var "applied")
+              ~rhs:(apply (nat 5) (variable (var "f") (function_ty pair_ty int_ty)))
+              ~in_:
+                (exec (nat 7) (variable (var "applied") (function_ty nat_ty int_ty)))))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 42 ;
+      LAMBDA
+        (pair nat (pair nat nat))
+        nat
+        { UNPAIR ; DUP 2 ; CDR ; DIG 2 ; CAR ; ADD ; SWAP ; ADD } ;
+      SWAP ;
+      APPLY ;
+      PUSH nat 5 ;
+      APPLY ;
+      PUSH nat 7 ;
+      EXEC }
+
+    Optimised:
+    { LAMBDA (pair nat (pair nat nat)) nat { UNPAIR ; SWAP ; UNPAIR ; ADD ; ADD } ;
+      PUSH nat 42 ;
+      APPLY ;
+      PUSH nat 5 ;
+      APPLY ;
+      PUSH nat 7 ;
+      EXEC } |}]
+
+let%expect_test "inner param overshadowing outer var name" =
+  let expr =
+    let_in (var "z") ~rhs:(nat 9)
+      ~in_:
+        (lambda (var "z", nat_ty)
+          ~body:(add (variable (var "z") nat_ty) (nat 1)))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 9 ; LAMBDA nat nat { PUSH nat 1 ; SWAP ; ADD } ; SWAP ; DROP }
+
+    Optimised:
+    { LAMBDA nat nat { PUSH nat 1 ; ADD } } |}]
+
+let%expect_test "lambda capturing a mut var read" =
+  let mut_m = mut_var "m" in
+  let expr =
+    let_mut_in mut_m ~rhs:(nat 10)
+      ~in_:
+        (lambda (var "x", nat_ty)
+          ~body:(add (variable (var "x") nat_ty) (deref mut_m nat_ty)))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 10 ;
+      LAMBDA (pair nat nat) nat { UNPAIR ; SWAP ; ADD } ;
+      SWAP ;
+      APPLY }
+
+    Optimised:
+    { LAMBDA (pair nat nat) nat { UNPAIR ; ADD } ; PUSH nat 10 ; APPLY } |}]
+
+let%expect_test "lambda capturing mut var and assigning" =
+  let mut_c = mut_var "c" in
+  let expr =
+    let_mut_in mut_c ~rhs:(nat 0)
+      ~in_:
+        (lambda (var "inc", nat_ty)
+          ~body:(
+            let_in (var "ignore_assign")
+              ~rhs:(assign mut_c (add (deref mut_c nat_ty) (variable (var "inc") nat_ty)))
+              ~in_:(deref mut_c nat_ty)
+          ))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 0 ;
+      LAMBDA
+        (pair nat nat)
+        nat
+        { UNPAIR ; SWAP ; DUP 2 ; ADD ; DUG 1 ; DIG 0 ; DROP ; UNIT ; DROP } ;
+      SWAP ;
+      APPLY }
+
+    Optimised:
+    { LAMBDA (pair nat nat) nat { UNPAIR ; ADD } ; PUSH nat 0 ; APPLY } |}]
+
+let%expect_test "partial apply nested lambda env capture" =
+  let param_ty = mk_tuple_ty [int_ty; int_ty] in
+  let outer_lam =
+    lambda (var "p", param_ty)
+      ~body:(
+        let_in (var "sum") ~rhs:(add
+                                   (add (car (variable (var "p") param_ty))
+                                        (cdr (variable (var "p") param_ty)))
+                                   (variable (var "a") nat_ty))
+          ~in_:
+            (lambda (var "leftover", int_ty)
+              ~body:(add (variable (var "sum") int_ty) (variable (var "leftover") int_ty)))
+      )
+  in
+  let expr =
+    let_in (var "a") ~rhs:(nat 3)
+      ~in_:
+        (let_in (var "outer") ~rhs:outer_lam
+          ~in_:
+            (let_in (var "applied_outer")
+              ~rhs:(app (variable (var "outer") (function_ty param_ty (function_ty int_ty int_ty)))
+                        (tuple (mk_row [
+                          Leaf(None, int 7);
+                          Leaf(None, int 5)
+                        ])))
+              ~in_:
+                ((app (variable (var "applied_outer") (function_ty int_ty int_ty)) (int 10)))))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH nat 3 ;
+      LAMBDA
+        (pair nat (pair int int))
+        (lambda int int)
+        { UNPAIR ;
+          DUP 2 ;
+          CDR ;
+          DIG 2 ;
+          CAR ;
+          ADD ;
+          ADD ;
+          LAMBDA (pair int int) int { UNPAIR ; SWAP ; SWAP ; ADD } ;
+          SWAP ;
+          APPLY } ;
+      SWAP ;
+      APPLY ;
+      PUSH int 5 ;
+      PUSH int 7 ;
+      PAIR ;
+      SWAP ;
+      SWAP ;
+      EXEC ;
+      PUSH int 10 ;
+      SWAP ;
+      SWAP ;
+      EXEC }
+
+    Optimised:
+    { LAMBDA
+        (pair nat (pair int int))
+        (lambda int int)
+        { UNPAIR ;
+          SWAP ;
+          UNPAIR ;
+          ADD ;
+          ADD ;
+          LAMBDA (pair int int) int { UNPAIR ; ADD } ;
+          SWAP ;
+          APPLY } ;
+      PUSH nat 3 ;
+      APPLY ;
+      PUSH int 5 ;
+      PUSH int 7 ;
+      PAIR ;
+      EXEC ;
+      PUSH int 10 ;
+      EXEC } |}]
+
+let%expect_test "return environment capturing function unused" =
+  let expr =
+    let_in (var "q") ~rhs:(int 123)
+      ~in_:
+        (lambda (var "x", int_ty)
+          ~body:(
+            lambda (var "y", int_ty)
+              ~body:(add (add (variable (var "x") int_ty) (variable (var "y") int_ty))
+                           (variable (var "q") int_ty))
+          ))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH int 123 ;
+      LAMBDA
+        (pair int int)
+        (lambda int int)
+        { UNPAIR ;
+          LAMBDA (pair int (pair int int)) int { UNPAIR 3 ; DIG 2 ; DIG 2 ; ADD ; ADD } ;
+          SWAP ;
+          APPLY ;
+          SWAP ;
+          APPLY } ;
+      SWAP ;
+      APPLY }
+
+    Optimised:
+    { LAMBDA
+        (pair int int)
+        (lambda int int)
+        { UNPAIR ;
+          LAMBDA (pair int (pair int int)) int { UNPAIR 3 ; DUG 2 ; ADD ; ADD } ;
+          SWAP ;
+          APPLY ;
+          SWAP ;
+          APPLY } ;
+      PUSH int 123 ;
+      APPLY } |}]
+
+let%expect_test "deeper let_in overshadowing environment var" =
+  let expr =
+    let_in (var "x") ~rhs:(int 1)
+      ~in_:
+        (lambda (var "y", int_ty)
+          ~body:(
+            let_in (var "x")
+              ~rhs:(add (variable (var "y") int_ty) (variable (var "x") int_ty))
+              ~in_:(add (variable (var "x") int_ty) (int 100))
+          ))
+  in
+  test_expr expr;
+  [%expect {|
+    { PUSH int 1 ;
+      LAMBDA
+        (pair int int)
+        int
+        { UNPAIR ; DUP 1 ; DIG 2 ; ADD ; PUSH int 100 ; SWAP ; ADD ; SWAP ; DROP } ;
+      SWAP ;
+      APPLY }
+
+    Optimised:
+    { LAMBDA (pair int int) int { UNPAIR ; ADD ; PUSH int 100 ; ADD } ;
+      PUSH int 1 ;
+      APPLY } |}]

--- a/test/test_nodes.ml
+++ b/test/test_nodes.ml
@@ -592,11 +592,17 @@ let%expect_test "assign same var multiple branches" =
       DUP 2 ;
       COMPARE ;
       EQ ;
-      IF { DROP ; PUSH nat 50 ; NEVER } { DROP ; PUSH nat 10 ; NEVER } }
+      IF { PUSH nat 50 ; SWAP ; SUB ; DROP ; UNIT }
+         { PUSH nat 10 ; SWAP ; SUB ; DROP ; UNIT } }
 
     Optimised:
-    { PUSH bool True ;
-      IF { PUSH nat 50 ; NEVER } { PUSH nat 10 ; NEVER } } |}]
+    { PUSH nat 100 ;
+      DUP ;
+      DUP 2 ;
+      COMPARE ;
+      EQ ;
+      IF { PUSH int -50 ; ADD ; DROP } { PUSH int -10 ; ADD ; DROP } ;
+      UNIT } |}]
 
 let%expect_test "assign inside for loop" =
   let idx = mut_var "i" in
@@ -1325,8 +1331,8 @@ let%expect_test "while with complex body" =
              DUP 2 ;
              COMPARE ;
              GE ;
-             IF { DROP ; PUSH nat 2 ; DROP ; UNIT }
-                { DROP ; PUSH nat 2 ; DROP ; UNIT } ;
+             IF { PUSH nat 2 ; SWAP ; DROP ; DROP ; UNIT }
+                { PUSH nat 2 ; SWAP ; DROP ; DROP ; UNIT } ;
              DROP ;
              PUSH nat 10 ;
              PUSH nat 0 ;
@@ -1843,7 +1849,7 @@ let%expect_test "match three branch" =
 (* Raw michelson *)
 let push_int n = 
   let open Tezos_micheline.Micheline in
-  Prim ( Ast_builder.Dummy_range.v, "PUSH", [Int (Ast_builder.Dummy_range.v, Z.of_int n) ], ["int"])
+  Prim ( Ast_builder.Dummy_range.v, "PUSH", [Tezos_micheline.Micheline.Prim (Ast_builder.Dummy_range.v, "int", [], []); Int (Ast_builder.Dummy_range.v, Z.of_int n) ], [])
 let seq_of_prim prim = Tezos_micheline.Micheline.Seq (Ast_builder.Dummy_range.v, [prim])
 let seq instrs = Tezos_micheline.Micheline.Seq (Ast_builder.Dummy_range.v, instrs)
 
@@ -1853,8 +1859,12 @@ let%expect_test "raw michelson single push int" =
     seq_of_prim (push_int 42)
   in
   let expr = raw_michelson michelson_ast [] int_ty in
-  test_expr ~optimise:false expr;
-  [%expect {| { { PUSH int 42 } } |}]
+  test_expr expr;
+  [%expect {|
+    { { PUSH int 42 } }
+
+    Optimised:
+    { PUSH int 42 } |}]
 
 let%expect_test "raw michelson multiple instructions" =
   let open Tezos_micheline.Micheline in
@@ -1867,8 +1877,12 @@ let%expect_test "raw michelson multiple instructions" =
       ])
   in
   let expr = raw_michelson michelson_ast [] int_ty in
-  test_expr ~optimise:false expr;
-  [%expect {| { { PUSH int 3 ; PUSH int 5 ; ADD } } |}]
+  test_expr expr;
+  [%expect {|
+    { { PUSH int 3 ; PUSH int 5 ; ADD } }
+
+    Optimised:
+    { PUSH int 8 } |}]
 
 let%expect_test "raw michelson with arguments" =
   let open Tezos_micheline.Micheline in
@@ -1877,20 +1891,28 @@ let%expect_test "raw michelson with arguments" =
       (Prim (Ast_builder.Dummy_range.v, "MUL", [], []))
   in
   let expr = raw_michelson michelson_ast [int 2; int 8] int_ty in
-  test_expr ~optimise:false expr;
-  [%expect {| { PUSH int 8 ; PUSH int 2 ; { MUL } } |}]
+  test_expr expr;
+  [%expect {|
+    { PUSH int 8 ; PUSH int 2 ; { MUL } }
+
+    Optimised:
+    { PUSH int 16 } |}]
 
 let%expect_test "raw michelson returning string" =
   let open Tezos_micheline.Micheline in
   let michelson_ast =
     Seq (Ast_builder.Dummy_range.v,
       [
-        Prim (Ast_builder.Dummy_range.v, "PUSH", [String (Ast_builder.Dummy_range.v, "hello")], ["string"])
+        Prim (Ast_builder.Dummy_range.v, "PUSH", [Tezos_micheline.Micheline.Prim (Ast_builder.Dummy_range.v, "string", [], []); String (Ast_builder.Dummy_range.v, "hello")], [])
       ])
   in
   let expr = raw_michelson michelson_ast [] string_ty in
-  test_expr ~optimise:false expr;
-  [%expect {| { { PUSH string "hello" } } |}]
+  test_expr expr;
+  [%expect {|
+    { { PUSH string "hello" } }
+
+    Optimised:
+    { PUSH string "hello" } |}]
 
 let%expect_test "raw michelson complex seq" =
   let open Tezos_micheline.Micheline in
@@ -1908,8 +1930,12 @@ let%expect_test "raw michelson complex seq" =
     Leaf (None, int_ty)
   ]))
   in
-  test_expr ~optimise:false expr;
-  [%expect {| { { PUSH int 10 ; PUSH int 20 ; PAIR ; DUP } } |}]
+  test_expr expr;
+  [%expect {|
+    { { PUSH int 10 ; PUSH int 20 ; PAIR ; DUP } }
+
+    Optimised:
+    { PUSH int 10 ; PUSH int 20 ; PAIR ; DUP } |}]
 
 let operation_list_ty =
   list_ty (operation_ty)
@@ -2229,7 +2255,7 @@ test_expr expr;
                NIL operation ;
                PAIR } } ;
     PAIR }
-  
+
   Optimised:
   { PUSH nat 10 ;
     PUSH mutez 1000 ;

--- a/test/test_used_vars.ml
+++ b/test/test_used_vars.ml
@@ -1,0 +1,530 @@
+open Core
+open Lltz_ir.Ast_builder.With_dummy
+module Last_vars = Lltz_codegen.Last_vars
+module Ast_builder = Lltz_ir.Ast_builder
+
+let print_used expr =
+  let vars = Last_vars.collect_used_vars expr in
+  vars
+  |> Set.to_list
+  |> List.sort ~compare:String.compare
+  |> String.concat ~sep:", "
+  |> print_endline
+
+let%expect_test "used var simple" =
+  let expr = variable (var "x") nat_ty in
+  print_used expr;
+  [%expect {|
+    x
+  |}]
+
+let%expect_test "used deref free" =
+  let expr = deref (mut_var "m") nat_ty in
+  print_used expr;
+  [%expect {|
+    m
+  |}]
+
+let%expect_test "used const" =
+  let expr = int 42 in
+  print_used expr;
+  [%expect {| |}]
+
+let%expect_test "used let_in overshadow" =
+  let expr =
+    let_in (var "x") ~rhs:(nat 1)
+      ~in_:(add (variable (var "x") nat_ty) (variable (var "x") nat_ty))
+  in
+  print_used expr;
+  [%expect {|
+    x
+  |}]
+
+let%expect_test "used let_mut_in referencing var in body" =
+  let expr =
+    let_mut_in (mut_var "m") ~rhs:(int 10)
+      ~in_:(assign (mut_var "m") (add (deref (mut_var "m") int_ty) (variable (var "x") int_ty)))
+  in
+  print_used expr;
+  [%expect {|
+    m, x
+  |}]
+
+let%expect_test "used lambda referencing outer var not bound" =
+  let lam_expr =
+    lambda (var "p", nat_ty)
+      ~body:(add (variable (var "p") nat_ty) (variable (var "freeVar") nat_ty))
+  in
+  print_used lam_expr;
+  [%expect {|
+    freeVar, p
+  |}]
+
+let%expect_test "used lambda_rec referencing outer var" =
+  let expr =
+    lambda_rec (var "f") (var "n", nat_ty)
+      ~body:(
+        if_bool
+          (le (variable (var "n") nat_ty) (variable (var "outerN") nat_ty))
+          ~then_:(variable (var "f") (function_ty nat_ty nat_ty)) 
+          ~else_:(app (variable (var "f") (function_ty nat_ty nat_ty)) (variable (var "n") nat_ty))
+      )
+  in
+  print_used expr;
+  [%expect {|
+    f, n, outerN
+  |}]
+
+let%expect_test "used app overshadow in abs + free var in arg" =
+  let abs_expr =
+    lambda (var "z", nat_ty)
+      ~body:(variable (var "z") nat_ty)
+  in
+  let arg_expr =
+    add (int 0) (variable (var "unboundArg") nat_ty)
+  in
+  let expr = app abs_expr arg_expr in
+  print_used expr;
+  [%expect {|
+    unboundArg, z
+  |}]
+
+let%expect_test "used partial application overshadow outer var" =
+  let pair_ty = mk_tuple_ty [int_ty; int_ty] in
+  let two_arg_fun =
+    lambda (var "p", pair_ty)
+      ~body:(
+        add (variable (var "outer") int_ty)
+          (add
+             (car (variable (var "p") pair_ty))
+             (cdr (variable (var "p") pair_ty)))
+      )
+  in
+  let expr =
+    let_in (var "outer") ~rhs:(int 100)
+      ~in_:
+        (let_in (var "two_arg_fun") ~rhs:two_arg_fun
+          ~in_:
+            (let_in (var "applied1")
+              ~rhs:(apply (int 10) (variable (var "two_arg_fun") (function_ty pair_ty int_ty)))
+              ~in_:
+                (exec (int 20) (variable (var "applied1") (function_ty int_ty int_ty)))))
+  in
+  print_used expr;
+  [%expect {|
+    applied1, outer, p, two_arg_fun
+  |}]
+
+let%expect_test "used partial apply overshadow leftover function" =
+  let pair_ty = mk_tuple_ty [int_ty; int_ty] in
+  let lambda_f =
+    lambda (var "p", pair_ty)
+      ~body:(
+        add
+          (variable (var "a") int_ty)
+          (add
+             (car (variable (var "p") pair_ty))
+             (cdr (variable (var "p") pair_ty)))
+      )
+  in
+  let expr =
+    let_in (var "a") ~rhs:(int 8)
+      ~in_:
+        (let_in (var "f") ~rhs:lambda_f
+          ~in_:
+            (let_in (var "partial")
+              ~rhs:(apply (int 2) (variable (var "f") (function_ty pair_ty int_ty)))
+              ~in_:
+                (let_in (var "leftover")
+                  ~rhs:(
+                    let_in (var "a") ~rhs:(int 999)
+                      ~in_:(variable (var "partial") (function_ty int_ty int_ty))
+                  )
+                  ~in_:
+                    (app (variable (var "leftover") (function_ty int_ty int_ty)) (int 3)))))
+  in
+  print_used expr;
+  [%expect {| a, f, leftover, p, partial |}]
+
+
+let%expect_test "used prim add" =
+  let expr =
+    add (variable (var "x") int_ty) (variable (var "y") int_ty)
+  in
+  print_used expr;
+  [%expect {|
+    x, y
+  |}]
+
+let%expect_test "used prim eq overshadow usage" =
+  let lhs = let_in (var "a") ~rhs:(nat 9) ~in_:(variable (var "a") nat_ty) in
+  let rhs = variable (var "a") nat_ty in
+  let expr = eq lhs rhs in
+  print_used expr;
+  [%expect {|
+    a
+  |}]
+
+let%expect_test "used div_ overshadow local var" =
+  let expr =
+    let_in (var "x") ~rhs:(int 50)
+      ~in_:
+        (div_
+          (variable (var "x") int_ty)
+          (let_in (var "x") ~rhs:(int 5) ~in_:(variable (var "x") int_ty)))
+  in
+  print_used expr;
+  [%expect {|
+    name_var_4sfa9wjas81, x
+  |}]
+
+  let%expect_test "used mod_ overshadow in lhs" =
+  let lhs_expr =
+    let_in (var "n") ~rhs:(int 7)
+      ~in_:(add (variable (var "n") int_ty) (int 2))
+  in
+  let expr = mod_ lhs_expr (variable (var "y") int_ty) in
+  print_used expr;
+  [%expect {|
+    n, name_var_4sfa9wjas82, y
+  |}]
+
+let%expect_test "used div_ with mutable var + overshadow in rhs" =
+  let lhs_expr =
+    let_mut_in (mut_var "m") ~rhs:(add (variable (var "x") int_ty) (int 1))
+      ~in_:(deref (mut_var "m") int_ty)
+  in
+  let rhs_expr =
+    let_in (var "v") ~rhs:(int 2)
+      ~in_:(variable (var "v") int_ty)
+  in
+  let expr = div_ lhs_expr rhs_expr in
+  print_used expr;
+  [%expect {|
+    m, name_var_4sfa9wjas83, v, x
+  |}]
+
+let%expect_test "used both div_ and mod_ combined" =
+  let a_expr = let_in (var "a") ~rhs:(int 10) ~in_:(variable (var "a") int_ty) in
+  let b_expr = let_in (var "b") ~rhs:(int 2)  ~in_:(variable (var "b") int_ty) in
+  let div_expr = div_ a_expr b_expr in
+  let expr = mod_ div_expr (variable (var "b") int_ty) in
+  print_used expr;
+  [%expect {|
+    a, b, name_var_4sfa9wjas84, name_var_4sfa9wjas85
+  |}]
+
+let%expect_test "used if_bool distinct free vars" =
+  let condition = eq (variable (var "condX") int_ty) (int 0) in
+  let then_expr = variable (var "thenVar") int_ty in
+  let else_expr = variable (var "elseVar") int_ty in
+  let expr = if_bool condition ~then_:then_expr ~else_:else_expr in
+  print_used expr;
+  [%expect {|
+    condX, elseVar, thenVar
+  |}]
+
+let%expect_test "used if_bool overshadow in condition + overshadow in then branch" =
+  let condition_expr =
+    let_in (var "a") ~rhs:(int 20)
+      ~in_:(eq (variable (var "a") int_ty) (variable (var "x") int_ty))
+  in
+  let then_expr =
+    let_in (var "x") ~rhs:(int 99)
+      ~in_:(variable (var "x") int_ty)
+  in
+  let else_expr = variable (var "x") int_ty in
+  let full_expr =
+    let_in (var "x") ~rhs:(int 10)
+      ~in_:(if_bool condition_expr ~then_:then_expr ~else_:else_expr)
+  in
+  print_used full_expr;
+  [%expect {| a, x |}]
+
+let%expect_test "used if_none referencing subject + some" =
+  let expr =
+    if_none (variable (var "optVal") (option_ty int_ty))
+      ~none:(int 100)
+      ~some:{
+        lam_var=(var "v", int_ty);
+        body=add (variable (var "v") int_ty) (variable (var "x") int_ty)
+      }
+  in
+  print_used expr;
+  [%expect {|
+    optVal, v, x
+  |}]
+
+let%expect_test "used if_cons overshadow lam_var1/lam_var2" =
+  let expr =
+    if_cons (variable (var "lst") (list_ty nat_ty))
+      ~empty:(int 0)
+      ~nonempty:{
+        lam_var1=(var "hd", nat_ty);
+        lam_var2=(var "hd", list_ty nat_ty);
+        body=add (variable (var "hd") nat_ty) (nat 2)
+      }
+  in
+  print_used expr;
+  [%expect {|
+    hd, lst
+  |}]
+
+let%expect_test "used if_left overshadow lam_var" =
+  let subject = variable (var "s") (or_ty (mk_row [
+    Leaf(None,int_ty); Leaf(None,int_ty)
+  ])) in
+  let expr =
+    if_left subject
+      ~left:{
+        lam_var=(var "l",int_ty);
+        body=let_in (var "l") ~rhs:(int 999)
+               ~in_:(int 1)
+      }
+      ~right:{
+        lam_var=(var "l",int_ty);
+        body=add (variable (var "l") int_ty) (int 2)
+      }
+  in
+  print_used expr;
+  [%expect {|
+    l, s
+  |}]
+
+let%expect_test "used while referencing cond, body" =
+  let expr =
+    while_
+      (lt (variable (var "x") nat_ty) (nat 5))
+      ~body:(assign (mut_var "m") (variable (var "x") nat_ty))
+  in
+  print_used expr;
+  [%expect {|
+    x
+  |}]
+
+let%expect_test "used while_left overshadow lam_var" =
+  let cond_expr = left (None,None, int_ty) (int 10) in
+  let expr = while_left cond_expr ~body:{ lam_var=(var "flag",int_ty); body=(right (None,None, int_ty) (variable (var "flag") int_ty)) } in
+  print_used expr;
+  [%expect {|
+    flag
+  |}]
+
+let%expect_test "used for usage" =
+  let expr =
+    for_ (mut_var "i")
+      ~init:(nat 0)
+      ~cond:(lt (deref (mut_var "i") nat_ty) (nat 5))
+      ~update:(assign (mut_var "i") (add (deref (mut_var "i") nat_ty) (nat 1)))
+      ~body:(assign (mut_var "m") (deref (mut_var "i") nat_ty))
+  in
+  print_used expr;
+  [%expect {|
+    i
+  |}]
+
+let%expect_test "used for overshadow in body referencing outer var" =
+  let mut_i = mut_var "i" in
+  let init_expr = nat 0 in
+  let cond_expr = lt (deref mut_i nat_ty) (nat 3) in
+  let update_expr = assign mut_i (add (deref mut_i nat_ty) (nat 1)) in
+  let body_expr =
+    let_in (var "i") ~rhs:(variable (var "outer") nat_ty)
+      ~in_:(add (variable (var "i") nat_ty) (nat 1))
+  in
+  let for_expr =
+    for_ mut_i ~init:init_expr ~cond:cond_expr ~update:update_expr ~body:body_expr
+  in
+  let full_expr =
+    let_in (var "outer") ~rhs:(nat 50)
+      ~in_:for_expr
+  in
+  print_used full_expr;
+  [%expect {| i, outer |}]
+
+
+let%expect_test "used for_each overshadow lam_var" =
+  let list_expr = nil int_ty in
+  let expr =
+    for_each list_expr
+      ~body:{
+        lam_var=(var "elem",int_ty);
+        body=let_in (var "elem") ~rhs:(int 999)
+               ~in_:(variable (var "elem") int_ty)
+      }
+  in
+  print_used expr;
+  [%expect {|
+    elem
+  |}]
+
+let%expect_test "used map referencing outer var" =
+  let list_expr = cons (nat 1) (nil nat_ty) in
+  let lam_body =
+    add (variable (var "x") nat_ty) (variable (var "outer") nat_ty)
+  in
+  let expr =
+    let_in (var "outer") ~rhs:(nat 2)
+      ~in_:(map list_expr ~map:{ lam_var=(var "x",nat_ty); body=lam_body })
+  in
+  print_used expr;
+  [%expect {|
+    outer, x
+  |}]
+
+let%expect_test "used fold_left overshadow lam_var" =
+  let coll = cons (nat 1) (nil nat_ty) in
+  let fold_body =
+    let_in (var "acc_x") ~rhs:(int 999)
+      ~in_:(nat 0)
+  in
+  let expr =
+    fold_left coll ~init:(nat 10)
+      ~fold:{ lam_var=(var "acc_x", tuple_ty (mk_row [
+        Leaf(None,nat_ty); Leaf(None,nat_ty)
+      ])); body=fold_body }
+  in
+  print_used expr;
+  [%expect {| |}]
+
+let%expect_test "used fold_right referencing outer var" =
+  let coll = cons (int 1) (nil int_ty) in
+  let expr =
+    let_in (var "outer") ~rhs:(int 100)
+      ~in_:
+        (fold_right coll ~init:(int 0)
+          ~fold:{
+            lam_var=(var "p", tuple_ty (mk_row [
+              Leaf(None,int_ty); Leaf(None,int_ty)
+            ]));
+            body=add
+              (car (variable (var "p") (mk_tuple_ty [int_ty; int_ty])))
+              (add
+                 (cdr (variable (var "p") (mk_tuple_ty [int_ty; int_ty])))
+                 (variable (var "outer") int_ty))
+          })
+  in
+  print_used expr;
+  [%expect {|
+    outer, p
+  |}]
+
+let%expect_test "used let_tuple_in overshadow" =
+  let triple =
+    tuple (mk_row [
+      Leaf(None, int 1);
+      Leaf(None, int 2);
+      Leaf(None, int 3)
+    ])
+  in
+  let expr =
+    let_tuple_in [var "a"; var "b"; var "a"]
+      ~rhs:triple
+      ~in_:(add (variable (var "a") int_ty) (variable (var "b") int_ty))
+  in
+  print_used expr;
+  [%expect {|
+    a, b
+  |}]
+
+let%expect_test "used tuple referencing x,y inside row" =
+  let expr =
+    tuple (mk_row [
+      Leaf(None, variable (var "x") nat_ty);
+      Leaf(None, variable (var "y") nat_ty)
+    ])
+  in
+  print_used expr;
+  [%expect {|
+    x, y
+  |}]
+
+let%expect_test "used proj referencing some var in the tuple" =
+  let tuple_expr =
+    tuple (mk_row [
+      Leaf(None, variable (var "alpha") int_ty);
+      Leaf(None, int 20)
+    ])
+  in
+  let expr =
+    proj tuple_expr ~path:(Here [0])
+  in
+  print_used expr;
+  [%expect {|
+    alpha
+  |}]
+
+let%expect_test "used update overshadow" =
+  let pair_expr =
+    tuple (mk_row [
+      Leaf(None, nat 10);
+      Leaf(None, nat 20)
+    ])
+  in
+  let upd_expr =
+    let_in (var "u") ~rhs:(nat 999)
+      ~in_:(variable (var "u") nat_ty)
+  in
+  let expr =
+    update_tuple pair_expr ~component:(Here [1]) ~update:upd_expr
+  in
+  print_used expr;
+  [%expect {|
+    u
+  |}]
+
+module MA = Michelson.Ast
+
+let push_int n = Tezos_micheline.Micheline.Prim(Ast_builder.Dummy_range.v, "PUSH", [Tezos_micheline.Micheline.Int(Ast_builder.Dummy_range.v, Z.of_int n)], [])
+
+let%expect_test "used raw_michelson overshadow" =
+  let code_ast = Tezos_micheline.Micheline.Seq (Ast_builder.Dummy_range.v, [ push_int 42 ]) in
+  let arg1 = variable (var "a1") int_ty in
+  let arg2 =
+    let_in (var "a1") ~rhs:(int 100)
+      ~in_:(variable (var "a1") int_ty)
+  in
+  let expr =
+    raw_michelson code_ast [arg1; arg2] int_ty
+  in
+  print_used expr;
+  [%expect {|
+    a1
+  |}]
+
+let%expect_test "used create_contract overshadow binder_var" =
+  let param_storage_ty = mk_tuple_ty [nat_ty; nat_ty] in
+  let code_body =
+    let_tuple_in [var "p"; var "s"]
+      ~rhs:(variable (var "args") param_storage_ty)
+      ~in_:(add (variable (var "p") nat_ty) (variable (var "s") nat_ty))
+  in
+  let expr =
+    create_contract
+      ~storage:nat_ty
+      ~code:{ lam_var=(var "args", param_storage_ty); body=code_body }
+      ~delegate:(variable (var "del") (option_ty key_hash_ty))
+      ~initial_balance:(variable (var "bal") mutez_ty)
+      ~initial_storage:(let_in (var "args") ~rhs:(nat 5) ~in_:(nat 6))
+  in
+  print_used expr;
+  [%expect {|
+    args, bal, del, p, s
+  |}]
+
+let%expect_test "used global_constant overshadow" =
+  let expr =
+    global_constant "myHash"
+      [
+        let_in (var "g") ~rhs:(int 10)
+          ~in_:(variable (var "g") int_ty);
+        variable (var "g") int_ty
+      ]
+      (int_ty)
+  in
+  print_used expr;
+  [%expect {|
+    g
+  |}]
+
+(* TODO: Inj/Match *)


### PR DESCRIPTION
# Context
This PR adds test for computation of last used vars and never used vars annotations. It additionally includes functions for pretty printing the AST with those annotations which are used by the tests, but are also a useful debugging tool.

# Manual testing
dune runtest -j 1 