### PR TITLE
Update links to octez.tezos.com/docs

### DIFF
--- a/gitlab-pages/docs/advanced/code-injection.md
+++ b/gitlab-pages/docs/advanced/code-injection.md
@@ -93,7 +93,7 @@ Contracts with embedded Michelson code are compiled normally like any
 other contract. We give an example of a contract that uses the type
 `never`, a new Michelson type that represents the empty type. You can
 read more about it
-[here](https://tezos.gitlab.io/active/michelson.html#operations-on-type-never).
+[here](https://tezos.gitlab.io/michelson-reference/#type-never).
 
 We will use the Michelson instruction `NEVER` to resolve a forbidden
 branch when matching on the parameter of our contract:

--- a/gitlab-pages/docs/compiling/deploying.md
+++ b/gitlab-pages/docs/compiling/deploying.md
@@ -7,7 +7,7 @@ LIGO doesn't include a built-in way to deploy (originate) contracts to Tezos.
 You can deploy contracts in the [LIGO IDE](https://ide.ligolang.org/) or use other tools that can deploy Tezos contracts.
 
 One popular tool is the
-[Octez client](https://tezos.gitlab.io/user/setup-client.html), which is a
+[Octez client](https://octez.tezos.com/docs/user/setup-client.html), which is a
 command-line client that runs many different kinds of Tezos operations. For
 installation instructions, see
 [Installing the Octez client](https://docs.tezos.com/developing/octez-client/installing)

--- a/gitlab-pages/docs/protocol/hangzhou.md
+++ b/gitlab-pages/docs/protocol/hangzhou.md
@@ -111,7 +111,7 @@ Exposes tezos timelock library function [create_chest_key](https://gitlab.com/te
 
 ### Timelock
 
-Extensive documentation about timelock can be found [here](https://tezos.gitlab.io/alpha/timelock.html#timelock).
+Extensive documentation about timelock can be found [here](https://octez.tezos.com/docs/alpha/timelock.html#timelock).
 Here is an example of a contract trying to open a chest and the corresponding tests to trigger all error kinds:
 
 <Syntax test-ligo syntax="cameligo">
@@ -178,7 +178,7 @@ let open_or_fail = ([ck, c, @time] : [chest_key, chest, nat]) : bytes => {
 
 ### On-chain views
 
-> Tezos documentation on views can be found [here](https://tezos.gitlab.io/011/michelson.html#operations-on-views)
+> Tezos documentation on views can be found [here](https://octez.tezos.com/docs/active/views.html)
 
 On-chain views are named routines attached to your contract allowing
 another contract to call them to get a "view" of your contract current

--- a/gitlab-pages/docs/protocol/mumbai.md
+++ b/gitlab-pages/docs/protocol/mumbai.md
@@ -12,7 +12,7 @@ import SyntaxTitle from '@theme/SyntaxTitle';
 
 ### Deprecation
 
-The type `tx_rollup_l2_address` has been disabled (see the [changelog](https://tezos.gitlab.io/protocols/016_mumbai.html#breaking-changes) for the Mumbai protocol).
+The type `tx_rollup_l2_address` has been disabled (see the [changelog](https://octez.tezos.com/docs/protocols/016_mumbai.html#breaking-changes) for the Mumbai protocol).
 
 ### New operators
 

--- a/gitlab-pages/docs/reference/current.md
+++ b/gitlab-pages/docs/reference/current.md
@@ -274,7 +274,7 @@ Get the default contract associated with an on-chain key-pair. This
 contract does not execute code, instead it exists to receive tokens on
 behalf of a key's owner.
 
-See also: http://tezos.gitlab.io/user/glossary.html#implicit-account
+See also: https://octez.tezos.com/docs/active/glossary.html#user-account
 
 <Syntax syntax="cameligo">
 
@@ -433,7 +433,7 @@ let set_delegate: (delegate: option&lt;key_hash&gt;) => operation
 
 
 
-Modify the [delegate](http://tezos.gitlab.io/user/glossary.html?highlight=delegate#delegate) of the current contract.
+Modify the [delegate](http://tezos.gitlab.io/user/glossary.html#delegate) of the current contract.
 
 The operation fails when:
 - the delegate is the same as current delegate

--- a/gitlab-pages/docs/testing/michelson_testing.md
+++ b/gitlab-pages/docs/testing/michelson_testing.md
@@ -17,7 +17,7 @@ There are two frameworks for testing Michelson contracts:
 You can also test compiled contracts in sandboxes and on test networks, which work in a way similar to Tezos Mainnet but do not have the same costs.
 Several options for sandboxes and testnets are available, including:
 
-- The Octez suite [mockup mode](https://tezos.gitlab.io/user/mockup.html) and [sandbox mode](https://tezos.gitlab.io/user/sandbox.html)
+- The Octez suite [mockup mode](https://octez.tezos.com/docs/user/mockup.html) and [sandbox mode](https://octez.tezos.com/docs/user/sandbox.html)
 - Local test networks such as [Flextesa](https://tezos.gitlab.io/flextesa/) and [Tezbox](https://github.com/tez-capital/tezbox)
 - Public test networks such as Ghostnet, which are listed at https://teztnets.com
 
@@ -122,7 +122,7 @@ Now you can follow these steps to deploy the compiled contract to the Octez clie
 1. Install the Octez client.
 
    One way is to install it via opam by running `opam install octez-client`.
-   For other installation methods, see [Installing Octez](https://tezos.gitlab.io/introduction/howtoget.html) in the Octez documentation.
+   For other installation methods, see [Installing Octez](https://octez.tezos.com/docs/introduction/howtoget.html) in the Octez documentation.
 
 1. Print a list of supported protocol versions by running `octez-client list mockup protocols`.
 

--- a/gitlab-pages/docs/tutorials/getting-started/getting-started.md
+++ b/gitlab-pages/docs/tutorials/getting-started/getting-started.md
@@ -414,7 +414,7 @@ The Ghostnet test network is just like the Tezos mainnet, so you can use it to t
    brew install tezos-client
    ```
 
-   - For other methods, see https://tezos.gitlab.io/introduction/howtoget.html.
+   - For other methods, see https://octez.tezos.com/docs/introduction/howtoget.html.
 
 1. Verify that you have at least version 20 of the Octez client by running `octez-client --version` and verifying that the version is at least 20.0.
 

--- a/gitlab-pages/docs/tutorials/tz-vs-eth/tz-vs-eth.md
+++ b/gitlab-pages/docs/tutorials/tz-vs-eth/tz-vs-eth.md
@@ -636,4 +636,4 @@ In this article, we discussed some Solidity patterns and their LIGO counterparts
 | `contract.doX(...)` | Emit an internal operation |
 | `uint x = contract.getX()` | Do not do this. Think if you can merge the contracts or reverse the execution flow |
 | Proxy upgrade pattern | Put lambdas to storage and provide means to update them |
-| `emit Event(...)` | Event logs are not supported at the moment. There is a [proposal](https://tezos.gitlab.io/protocols/014_kathmandu.html#contract-event-logging) to support event logs in the future |
+| `emit Event(...)` | Event logs are not supported at the moment. There is a [proposal](https://octez.tezos.com/docs/protocols/014_kathmandu.html#contract-event-logging) to support event logs in the future |

--- a/gitlab-pages/website/versioned_docs/version-1.5.0/advanced/code-injection.md
+++ b/gitlab-pages/website/versioned_docs/version-1.5.0/advanced/code-injection.md
@@ -93,7 +93,7 @@ Contracts with embedded Michelson code are compiled normally like any
 other contract. We give an example of a contract that uses the type
 `never`, a new Michelson type that represents the empty type. You can
 read more about it
-[here](https://tezos.gitlab.io/active/michelson.html#operations-on-type-never).
+[here](https://tezos.gitlab.io/michelson-reference/#type-never).
 
 We will use the Michelson instruction `NEVER` to resolve a forbidden
 branch when matching on the parameter of our contract:

--- a/gitlab-pages/website/versioned_docs/version-1.5.0/advanced/michelson.md
+++ b/gitlab-pages/website/versioned_docs/version-1.5.0/advanced/michelson.md
@@ -3,7 +3,7 @@ id: michelson-and-ligo
 title: Michelson and LIGO
 ---
 
-Currently LIGO compiles to [Michelson](https://tezos.gitlab.io/whitedoc/michelson.html),
+Currently LIGO compiles to [Michelson](https://octez.tezos.com/docs/active/michelson.html),
 the native smart contract language supported by Tezos. This page explains the
 relationship between LIGO and the underlying Michelson it compiles to. Understanding
 Michelson is not a requirement to use LIGO, but it does become important if you want
@@ -81,7 +81,7 @@ Here is an example of a Michelson contract.
 ```
 
 The contract above maintains an `int` as its storage. It has two
-[entrypoints](https://tezos.gitlab.io/whitedoc/michelson.html#entrypoints),
+[entrypoints](https://octez.tezos.com/docs/active/michelson.html#entrypoints),
 `add` and `sub`, to modify it, and the `default` entrypoint of type
 `unit` will reset it to `0`.
 

--- a/gitlab-pages/website/versioned_docs/version-1.5.0/advanced/michelson_testing.md
+++ b/gitlab-pages/website/versioned_docs/version-1.5.0/advanced/michelson_testing.md
@@ -17,7 +17,7 @@ test contracts in Michelson:
 
 Another alternative is to use Tezos's binary `tezos-client`
 directly. There's a new
-[mockup](https://tezos.gitlab.io/user/mockup.html) mode which is does
+[mockup](https://octez.tezos.com/docs/user/mockup.html) mode which is does
 not need a Tezos node to be running (albeit this is less similar to
 mainnet than running a Tezos sandbox node).
 

--- a/gitlab-pages/website/versioned_docs/version-1.5.0/advanced/testing.md
+++ b/gitlab-pages/website/versioned_docs/version-1.5.0/advanced/testing.md
@@ -211,7 +211,7 @@ and then show you how to handle it.
 
 There is two kind of operations in the protocol : external and internal.
 `internal operations` are those created by smart contracts and `external operations` are those created from outside the chain
-(e.g. using `Test.originate` or `tezos-client` for instance) [more information here](https://tezos.gitlab.io/active/michelson.html#semantics-of-smart-contracts-and-transactions)
+(e.g. using `Test.originate` or `tezos-client` for instance) [more information here](https://octez.tezos.com/docs/active/michelson.html#semantics-of-smart-contracts-and-transactions)
 
 In the protocol, both external and internal `transfer`/`origination` operations contains a piece of michelson code representing the `parameter`/`initial storage`.
 Now imagine you have a value of type `parameter_ty`/`storage_ty` containing a ticket, that you want to transfer or originate,

--- a/gitlab-pages/website/versioned_docs/version-1.5.0/protocol/hangzhou.md
+++ b/gitlab-pages/website/versioned_docs/version-1.5.0/protocol/hangzhou.md
@@ -141,7 +141,7 @@ Exposes tezos timelock library function [create_chest_key](https://gitlab.com/te
 
 ### Timelock
 
-Extensive documentation about timelock can be found [here](https://tezos.gitlab.io/alpha/timelock.html#timelock).
+Extensive documentation about timelock can be found [here](https://octez.tezos.com/docs/active/timelock.html#timelock).
 Here is an example of a contract trying to open a chest and the corresponding tests to trigger all error kinds:
 
 <Syntax test-ligo syntax="cameligo">
@@ -221,7 +221,7 @@ function open_or_fail (const ck : chest_key; const c : chest; const @time : nat)
 
 ### On-chain views
 
-> Tezos documentation on views can be found [here](https://tezos.gitlab.io/011/michelson.html#operations-on-views)
+> Tezos documentation on views can be found [here](https://octez.tezos.com/docs/active/views.html)
 
 On-chain views are named routines attached to your contract allowing
 another contract to call them to get a "view" of your contract current

--- a/gitlab-pages/website/versioned_docs/version-1.5.0/protocol/mumbai.md
+++ b/gitlab-pages/website/versioned_docs/version-1.5.0/protocol/mumbai.md
@@ -12,7 +12,7 @@ import SyntaxTitle from '@theme/SyntaxTitle';
 
 ### Deprecation
 
-The type `tx_rollup_l2_address` has been disabled (see the [changelog](https://tezos.gitlab.io/protocols/016_mumbai.html#breaking-changes) for the Mumbai protocol).
+The type `tx_rollup_l2_address` has been disabled (see the [changelog](https://octez.tezos.com/docs/protocols/016_mumbai.html#breaking-changes) for the Mumbai protocol).
 
 ### New operators
 

--- a/gitlab-pages/website/versioned_docs/version-1.5.0/reference/current.md
+++ b/gitlab-pages/website/versioned_docs/version-1.5.0/reference/current.md
@@ -274,7 +274,7 @@ Get the default contract associated with an on-chain key-pair. This
 contract does not execute code, instead it exists to receive tokens on
 behalf of a key's owner.
 
-See also: http://tezos.gitlab.io/user/glossary.html#implicit-account
+See also: https://octez.tezos.com/docs/active/glossary.html#user-account
 
 <Syntax syntax="cameligo">
 
@@ -433,7 +433,7 @@ let set_delegate: (delegate: option&lt;key_hash&gt;) => operation
 
 
 
-Modify the [delegate](http://tezos.gitlab.io/user/glossary.html?highlight=delegate#delegate) of the current contract.
+Modify the [delegate](http://octez.tezos.com/docs/user/glossary.html?highlight=delegate#delegate) of the current contract.
 
 The operation fails when:
 - the delegate is the same as current delegate

--- a/gitlab-pages/website/versioned_docs/version-1.5.0/tezos/contracts/michelson.md
+++ b/gitlab-pages/website/versioned_docs/version-1.5.0/tezos/contracts/michelson.md
@@ -4,7 +4,7 @@ title: Michelson
 ---
 
 Currently LIGO compiles to
-[Michelson](https://tezos.gitlab.io/whitedoc/michelson.html), the
+[Michelson](https://octez.tezos.com/docs/active/michelson.html), the
 native smart contract language supported by Tezos. This page explains
 the relationship between LIGO and the underlying Michelson it compiles
 to. Understanding Michelson is not a requirement to use LIGO, but it
@@ -84,7 +84,7 @@ Here is an example of a Michelson contract.
 ```
 
 The contract above maintains an `int` as its storage. It has two
-[entrypoints](https://tezos.gitlab.io/whitedoc/michelson.html#entrypoints),
+[entrypoints](https://octez.tezos.com/docs/whitedoc/michelson.html#entrypoints),
 `add` and `sub`, to modify it, and the `default` entrypoint of type
 `unit` will reset it to `0`.
 

--- a/gitlab-pages/website/versioned_docs/version-1.5.0/tutorials/getting-started/getting-started.md
+++ b/gitlab-pages/website/versioned_docs/version-1.5.0/tutorials/getting-started/getting-started.md
@@ -16,14 +16,14 @@ Two choices are offered, ideal if you want to work with Ligo :
 - Install necessary stuff onto your machine
     - [Ligo compiler](https://ligolang.org/docs/intro/installation) to compile your code.
     - [IDE plugins](https://ligolang.org/docs/intro/editor-support)
-    - [octez-client](https://tezos.gitlab.io/introduction/howtoget.html) used to interact with tezos blockchain. Pre-built binaries are available [here](https://github.com/serokell/tezos-packaging)
+    - [octez-client](https://octez.tezos.com/docs/introduction/howtoget.html) used to interact with tezos blockchain. Pre-built binaries are available [here](https://github.com/serokell/tezos-packaging)
 - Use [webide](https://ide.ligolang.org), ideal if you want a quick view of ligo. You'll be able to do, test, dry-run, and deploy the code !
 
 ## Building a smart-contract.
 
 We will use a simple  smart contract in this section and the following one. A counter that is available on a homepage.
 
-First, create a `ligo_tutorial` folder on your computer.  
+First, create a `ligo_tutorial` folder on your computer.
 `mligo` is the extension of cameligo file and `jsligo` for the jsligo file.
 
 <Syntax syntax="cameligo">
@@ -312,7 +312,7 @@ octez-client call counter from <my_tz_address...> \
 ```
 
 
-arg is obtained by compiling ligo expression onto michelson 
+arg is obtained by compiling ligo expression onto michelson
 
 <Syntax syntax="cameligo">
 
@@ -335,7 +335,7 @@ If you do so, back to `tzkt`, you will see several information on the operation,
 
 ## Testing the Michelson contract locally
 
-It can be annoying to deploy you contract onto a node to test it. We advise testing that [the Michelson code locally using mockup environment](https://tezos.gitlab.io/user/mockup.html). It'll allow to automate end to end tests in simulated environment
+It can be annoying to deploy you contract onto a node to test it. We advise testing that [the Michelson code locally using mockup environment](https://octez.tezos.com/docs/user/mockup.html). It'll allow to automate end to end tests in simulated environment
 
 This conclude this part of our tutorial.
 You should now be able to compile, test, publish and call a contract.

--- a/gitlab-pages/website/versioned_docs/version-1.5.0/tutorials/tz-vs-eth/tz-vs-eth.md
+++ b/gitlab-pages/website/versioned_docs/version-1.5.0/tutorials/tz-vs-eth/tz-vs-eth.md
@@ -636,4 +636,4 @@ In this article, we discussed some Solidity patterns and their LIGO counterparts
 | `contract.doX(...)` | Emit an internal operation |
 | `uint x = contract.getX()` | Do not do this. Think if you can merge the contracts or reverse the execution flow |
 | Proxy upgrade pattern | Put lambdas to storage and provide means to update them |
-| `emit Event(...)` | Event logs are not supported at the moment. There is a [proposal](https://tezos.gitlab.io/protocols/014_kathmandu.html#contract-event-logging) to support event logs in the future |
+| `emit Event(...)` | Event logs are not supported at the moment. There is a [proposal](https://octez.tezos.com/docs/protocols/014_kathmandu.html#contract-event-logging) to support event logs in the future |

--- a/gitlab-pages/website/versioned_docs/version-1.6.0/advanced/code-injection.md
+++ b/gitlab-pages/website/versioned_docs/version-1.6.0/advanced/code-injection.md
@@ -93,7 +93,7 @@ Contracts with embedded Michelson code are compiled normally like any
 other contract. We give an example of a contract that uses the type
 `never`, a new Michelson type that represents the empty type. You can
 read more about it
-[here](https://tezos.gitlab.io/active/michelson.html#operations-on-type-never).
+[here](https://tezos.gitlab.io/michelson-reference/#type-never).
 
 We will use the Michelson instruction `NEVER` to resolve a forbidden
 branch when matching on the parameter of our contract:

--- a/gitlab-pages/website/versioned_docs/version-1.6.0/advanced/michelson.md
+++ b/gitlab-pages/website/versioned_docs/version-1.6.0/advanced/michelson.md
@@ -3,7 +3,7 @@ id: michelson-and-ligo
 title: Michelson and LIGO
 ---
 
-Currently LIGO compiles to [Michelson](https://tezos.gitlab.io/whitedoc/michelson.html),
+Currently LIGO compiles to [Michelson](https://octez.tezos.com/docs/active/michelson.html),
 the native smart contract language supported by Tezos. This page explains the
 relationship between LIGO and the underlying Michelson it compiles to. Understanding
 Michelson is not a requirement to use LIGO, but it does become important if you want
@@ -81,7 +81,7 @@ Here is an example of a Michelson contract.
 ```
 
 The contract above maintains an `int` as its storage. It has two
-[entrypoints](https://tezos.gitlab.io/whitedoc/michelson.html#entrypoints),
+[entrypoints](https://octez.tezos.com/docs/active/michelson.html#entrypoints),
 `add` and `sub`, to modify it, and the `default` entrypoint of type
 `unit` will reset it to `0`.
 

--- a/gitlab-pages/website/versioned_docs/version-1.6.0/advanced/michelson_testing.md
+++ b/gitlab-pages/website/versioned_docs/version-1.6.0/advanced/michelson_testing.md
@@ -17,7 +17,7 @@ test contracts in Michelson:
 
 Another alternative is to use Tezos's binary `tezos-client`
 directly. There's a new
-[mockup](https://tezos.gitlab.io/user/mockup.html) mode which is does
+[mockup](https://octez.tezos.com/docs/user/mockup.html) mode which is does
 not need a Tezos node to be running (albeit this is less similar to
 mainnet than running a Tezos sandbox node).
 

--- a/gitlab-pages/website/versioned_docs/version-1.6.0/advanced/testing.md
+++ b/gitlab-pages/website/versioned_docs/version-1.6.0/advanced/testing.md
@@ -211,7 +211,7 @@ and then show you how to handle it.
 
 There is two kind of operations in the protocol : external and internal.
 `internal operations` are those created by smart contracts and `external operations` are those created from outside the chain
-(e.g. using `Test.originate` or `tezos-client` for instance) [more information here](https://tezos.gitlab.io/active/michelson.html#semantics-of-smart-contracts-and-transactions)
+(e.g. using `Test.originate` or `tezos-client` for instance) [more information here](https://octez.tezos.com/docs/active/michelson.html#semantics-of-smart-contracts-and-transactions)
 
 In the protocol, both external and internal `transfer`/`origination` operations contains a piece of michelson code representing the `parameter`/`initial storage`.
 Now imagine you have a value of type `parameter_ty`/`storage_ty` containing a ticket, that you want to transfer or originate,

--- a/gitlab-pages/website/versioned_docs/version-1.6.0/protocol/hangzhou.md
+++ b/gitlab-pages/website/versioned_docs/version-1.6.0/protocol/hangzhou.md
@@ -111,7 +111,7 @@ Exposes tezos timelock library function [create_chest_key](https://gitlab.com/te
 
 ### Timelock
 
-Extensive documentation about timelock can be found [here](https://tezos.gitlab.io/alpha/timelock.html#timelock).
+Extensive documentation about timelock can be found [here](https://octez.tezos.com/docs/active/timelock.html#timelock).
 Here is an example of a contract trying to open a chest and the corresponding tests to trigger all error kinds:
 
 <Syntax test-ligo syntax="cameligo">
@@ -178,7 +178,7 @@ let open_or_fail = ([ck, c, @time] : [chest_key, chest, nat]) : bytes => {
 
 ### On-chain views
 
-> Tezos documentation on views can be found [here](https://tezos.gitlab.io/011/michelson.html#operations-on-views)
+> Tezos documentation on views can be found [here](https://octez.tezos.com/docs/active/views.html)
 
 On-chain views are named routines attached to your contract allowing
 another contract to call them to get a "view" of your contract current

--- a/gitlab-pages/website/versioned_docs/version-1.6.0/protocol/mumbai.md
+++ b/gitlab-pages/website/versioned_docs/version-1.6.0/protocol/mumbai.md
@@ -12,7 +12,7 @@ import SyntaxTitle from '@theme/SyntaxTitle';
 
 ### Deprecation
 
-The type `tx_rollup_l2_address` has been disabled (see the [changelog](https://tezos.gitlab.io/protocols/016_mumbai.html#breaking-changes) for the Mumbai protocol).
+The type `tx_rollup_l2_address` has been disabled (see the [changelog](https://octez.tezos.com/docs/protocols/016_mumbai.html#breaking-changes) for the Mumbai protocol).
 
 ### New operators
 

--- a/gitlab-pages/website/versioned_docs/version-1.6.0/reference/current.md
+++ b/gitlab-pages/website/versioned_docs/version-1.6.0/reference/current.md
@@ -274,7 +274,7 @@ Get the default contract associated with an on-chain key-pair. This
 contract does not execute code, instead it exists to receive tokens on
 behalf of a key's owner.
 
-See also: http://tezos.gitlab.io/user/glossary.html#implicit-account
+See also: https://octez.tezos.com/docs/active/glossary.html#user-account
 
 <Syntax syntax="cameligo">
 
@@ -433,7 +433,7 @@ let set_delegate: (delegate: option&lt;key_hash&gt;) => operation
 
 
 
-Modify the [delegate](http://tezos.gitlab.io/user/glossary.html?highlight=delegate#delegate) of the current contract.
+Modify the [delegate](https://octez.tezos.com/docs/active/glossary.html#delegate) of the current contract.
 
 The operation fails when:
 - the delegate is the same as current delegate

--- a/gitlab-pages/website/versioned_docs/version-1.6.0/tezos/contracts/michelson.md
+++ b/gitlab-pages/website/versioned_docs/version-1.6.0/tezos/contracts/michelson.md
@@ -4,7 +4,7 @@ title: Michelson
 ---
 
 Currently LIGO compiles to
-[Michelson](https://tezos.gitlab.io/whitedoc/michelson.html), the
+[Michelson](https://octez.tezos.com/docs/active/michelson.html), the
 native smart contract language supported by Tezos. This page explains
 the relationship between LIGO and the underlying Michelson it compiles
 to. Understanding Michelson is not a requirement to use LIGO, but it
@@ -84,7 +84,7 @@ Here is an example of a Michelson contract.
 ```
 
 The contract above maintains an `int` as its storage. It has two
-[entrypoints](https://tezos.gitlab.io/whitedoc/michelson.html#entrypoints),
+[entrypoints](https://octez.tezos.com/docs/active/michelson.html#entrypoints),
 `add` and `sub`, to modify it, and the `default` entrypoint of type
 `unit` will reset it to `0`.
 

--- a/gitlab-pages/website/versioned_docs/version-1.6.0/tutorials/getting-started/getting-started.md
+++ b/gitlab-pages/website/versioned_docs/version-1.6.0/tutorials/getting-started/getting-started.md
@@ -16,14 +16,14 @@ Two choices are offered, ideal if you want to work with Ligo :
 - Install necessary stuff onto your machine
     - [Ligo compiler](https://ligolang.org/docs/intro/installation) to compile your code.
     - [IDE plugins](https://ligolang.org/docs/intro/editor-support)
-    - [octez-client](https://tezos.gitlab.io/introduction/howtoget.html) used to interact with tezos blockchain. Pre-built binaries are available [here](https://github.com/serokell/tezos-packaging)
+    - [octez-client](https://octez.tezos.com/docs/introduction/howtoget.html) used to interact with tezos blockchain. Pre-built binaries are available [here](https://github.com/serokell/tezos-packaging)
 - Use [webide](https://ide.ligolang.org), ideal if you want a quick view of ligo. You'll be able to do, test, dry-run, and deploy the code !
 
 ## Building a smart-contract.
 
 We will use a simple  smart contract in this section and the following one. A counter that is available on a homepage.
 
-First, create a `ligo_tutorial` folder on your computer.  
+First, create a `ligo_tutorial` folder on your computer.
 `mligo` is the extension of cameligo file and `jsligo` for the jsligo file.
 
 <Syntax syntax="cameligo">
@@ -312,7 +312,7 @@ octez-client call counter from <my_tz_address...> \
 ```
 
 
-arg is obtained by compiling ligo expression onto michelson 
+arg is obtained by compiling ligo expression onto michelson
 
 <Syntax syntax="cameligo">
 
@@ -335,7 +335,7 @@ If you do so, back to `tzkt`, you will see several information on the operation,
 
 ## Testing the Michelson contract locally
 
-It can be annoying to deploy you contract onto a node to test it. We advise testing that [the Michelson code locally using mockup environment](https://tezos.gitlab.io/user/mockup.html). It'll allow to automate end to end tests in simulated environment
+It can be annoying to deploy you contract onto a node to test it. We advise testing that [the Michelson code locally using mockup environment](https://octez.tezos.com/docs/user/mockup.html). It'll allow to automate end to end tests in simulated environment
 
 This conclude this part of our tutorial.
 You should now be able to compile, test, publish and call a contract.

--- a/gitlab-pages/website/versioned_docs/version-1.6.0/tutorials/tz-vs-eth/tz-vs-eth.md
+++ b/gitlab-pages/website/versioned_docs/version-1.6.0/tutorials/tz-vs-eth/tz-vs-eth.md
@@ -636,4 +636,4 @@ In this article, we discussed some Solidity patterns and their LIGO counterparts
 | `contract.doX(...)` | Emit an internal operation |
 | `uint x = contract.getX()` | Do not do this. Think if you can merge the contracts or reverse the execution flow |
 | Proxy upgrade pattern | Put lambdas to storage and provide means to update them |
-| `emit Event(...)` | Event logs are not supported at the moment. There is a [proposal](https://tezos.gitlab.io/protocols/014_kathmandu.html#contract-event-logging) to support event logs in the future |
+| `emit Event(...)` | Event logs are not supported at the moment. There is a [proposal](https://octez.tezos.com/docs/protocols/014_kathmandu.html#contract-event-logging) to support event logs in the future |

--- a/gitlab-pages/website/versioned_docs/version-1.9.2/advanced/code-injection.md
+++ b/gitlab-pages/website/versioned_docs/version-1.9.2/advanced/code-injection.md
@@ -93,7 +93,7 @@ Contracts with embedded Michelson code are compiled normally like any
 other contract. We give an example of a contract that uses the type
 `never`, a new Michelson type that represents the empty type. You can
 read more about it
-[here](https://tezos.gitlab.io/active/michelson.html#operations-on-type-never).
+[here](https://tezos.gitlab.io/michelson-reference/#type-never).
 
 We will use the Michelson instruction `NEVER` to resolve a forbidden
 branch when matching on the parameter of our contract:

--- a/gitlab-pages/website/versioned_docs/version-1.9.2/compiling/deploying.md
+++ b/gitlab-pages/website/versioned_docs/version-1.9.2/compiling/deploying.md
@@ -7,7 +7,7 @@ LIGO doesn't include a built-in way to deploy (originate) contracts to Tezos.
 You can deploy contracts in the [LIGO IDE](https://ide.ligolang.org/) or use other tools that can deploy Tezos contracts.
 
 One popular tool is the
-[Octez client](https://tezos.gitlab.io/user/setup-client.html), which is a
+[Octez client](https://octez.tezos.com/docs/user/setup-client.html), which is a
 command-line client that runs many different kinds of Tezos operations. For
 installation instructions, see
 [Installing the Octez client](https://docs.tezos.com/developing/octez-client/installing)

--- a/gitlab-pages/website/versioned_docs/version-1.9.2/protocol/hangzhou.md
+++ b/gitlab-pages/website/versioned_docs/version-1.9.2/protocol/hangzhou.md
@@ -111,7 +111,7 @@ Exposes tezos timelock library function [create_chest_key](https://gitlab.com/te
 
 ### Timelock
 
-Extensive documentation about timelock can be found [here](https://tezos.gitlab.io/alpha/timelock.html#timelock).
+Extensive documentation about timelock can be found [here](https://octez.tezos.com/docs/active/timelock.html#timelock).
 Here is an example of a contract trying to open a chest and the corresponding tests to trigger all error kinds:
 
 <Syntax test-ligo syntax="cameligo">
@@ -178,7 +178,7 @@ let open_or_fail = ([ck, c, @time] : [chest_key, chest, nat]) : bytes => {
 
 ### On-chain views
 
-> Tezos documentation on views can be found [here](https://tezos.gitlab.io/011/michelson.html#operations-on-views)
+> Tezos documentation on views can be found [here](https://octez.tezos.com/docs/active/views.html)
 
 On-chain views are named routines attached to your contract allowing
 another contract to call them to get a "view" of your contract current

--- a/gitlab-pages/website/versioned_docs/version-1.9.2/protocol/mumbai.md
+++ b/gitlab-pages/website/versioned_docs/version-1.9.2/protocol/mumbai.md
@@ -12,7 +12,7 @@ import SyntaxTitle from '@theme/SyntaxTitle';
 
 ### Deprecation
 
-The type `tx_rollup_l2_address` has been disabled (see the [changelog](https://tezos.gitlab.io/protocols/016_mumbai.html#breaking-changes) for the Mumbai protocol).
+The type `tx_rollup_l2_address` has been disabled (see the [changelog](https://octez.tezos.com/docs/protocols/016_mumbai.html#breaking-changes) for the Mumbai protocol).
 
 ### New operators
 

--- a/gitlab-pages/website/versioned_docs/version-1.9.2/reference/current.md
+++ b/gitlab-pages/website/versioned_docs/version-1.9.2/reference/current.md
@@ -274,7 +274,7 @@ Get the default contract associated with an on-chain key-pair. This
 contract does not execute code, instead it exists to receive tokens on
 behalf of a key's owner.
 
-See also: http://tezos.gitlab.io/user/glossary.html#implicit-account
+See also: https://octez.tezos.com/docs/active/glossary.html#user-account
 
 <Syntax syntax="cameligo">
 
@@ -433,7 +433,7 @@ let set_delegate: (delegate: option&lt;key_hash&gt;) => operation
 
 
 
-Modify the [delegate](http://tezos.gitlab.io/user/glossary.html?highlight=delegate#delegate) of the current contract.
+Modify the [delegate](https://octez.tezos.com/docs/active/glossary.html#delegate) of the current contract.
 
 The operation fails when:
 - the delegate is the same as current delegate

--- a/gitlab-pages/website/versioned_docs/version-1.9.2/testing/michelson_testing.md
+++ b/gitlab-pages/website/versioned_docs/version-1.9.2/testing/michelson_testing.md
@@ -17,7 +17,7 @@ There are two frameworks for testing Michelson contracts:
 You can also test compiled contracts in sandboxes and on test networks, which work in a way similar to Tezos Mainnet but do not have the same costs.
 Several options for sandboxes and testnets are available, including:
 
-- The Octez suite [mockup mode](https://tezos.gitlab.io/user/mockup.html) and [sandbox mode](https://tezos.gitlab.io/user/sandbox.html)
+- The Octez suite [mockup mode](https://octez.tezos.com/docs/user/mockup.html) and [sandbox mode](https://octez.tezos.com/docs/user/sandbox.html)
 - Local test networks such as [Flextesa](https://tezos.gitlab.io/flextesa/) and [Tezbox](https://github.com/tez-capital/tezbox)
 - Public test networks such as Ghostnet, which are listed at https://teztnets.com
 
@@ -122,7 +122,7 @@ Now you can follow these steps to deploy the compiled contract to the Octez clie
 1. Install the Octez client.
 
    One way is to install it via opam by running `opam install octez-client`.
-   For other installation methods, see [Installing Octez](https://tezos.gitlab.io/introduction/howtoget.html) in the Octez documentation.
+   For other installation methods, see [Installing Octez](https://octez.tezos.com/docs/introduction/howtoget.html) in the Octez documentation.
 
 1. Print a list of supported protocol versions by running `octez-client list mockup protocols`.
 

--- a/gitlab-pages/website/versioned_docs/version-1.9.2/tutorials/getting-started/getting-started.md
+++ b/gitlab-pages/website/versioned_docs/version-1.9.2/tutorials/getting-started/getting-started.md
@@ -414,7 +414,7 @@ The Ghostnet test network is just like the Tezos mainnet, so you can use it to t
    brew install tezos-client
    ```
 
-   - For other methods, see https://tezos.gitlab.io/introduction/howtoget.html.
+   - For other methods, see https://octez.tezos.com/docs/introduction/howtoget.html.
 
 1. Verify that you have at least version 20 of the Octez client by running `octez-client --version` and verifying that the version is at least 20.0.
 

--- a/gitlab-pages/website/versioned_docs/version-1.9.2/tutorials/tz-vs-eth/tz-vs-eth.md
+++ b/gitlab-pages/website/versioned_docs/version-1.9.2/tutorials/tz-vs-eth/tz-vs-eth.md
@@ -636,4 +636,4 @@ In this article, we discussed some Solidity patterns and their LIGO counterparts
 | `contract.doX(...)` | Emit an internal operation |
 | `uint x = contract.getX()` | Do not do this. Think if you can merge the contracts or reverse the execution flow |
 | Proxy upgrade pattern | Put lambdas to storage and provide means to update them |
-| `emit Event(...)` | Event logs are not supported at the moment. There is a [proposal](https://tezos.gitlab.io/protocols/014_kathmandu.html#contract-event-logging) to support event logs in the future |
+| `emit Event(...)` | Event logs are not supported at the moment. There is a [proposal](https://octez.tezos.com/docs/protocols/014_kathmandu.html#contract-event-logging) to support event logs in the future |


### PR DESCRIPTION
The Octez docs have moved to octez.tezos.com/docs.