### PR TITLE
feat(lltz_codegen): warnings fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     "lltz": {
       "flake": false,
       "locked": {
-        "lastModified": 1740059309,
-        "narHash": "sha256-EGv7r9paCNM9xhU4L3rUysIbH8ewaXfYITdUaygQFrI=",
+        "lastModified": 1741706101,
+        "narHash": "sha256-8m/pjdP6NAMuBSixlgoIUNaCi4lqloJ4BkSqN8KwDeQ=",
         "owner": "trilitech",
         "repo": "lltz",
-        "rev": "770794f0d9b2b254cee48c09c3b1862d96aa3ef8",
+        "rev": "df80fca90a745fda6e9df776e10c6ca9939ea2b5",
         "type": "github"
       },
       "original": {

--- a/src/main/compile/of_mini_c.ml
+++ b/src/main/compile/of_mini_c.ml
@@ -87,7 +87,7 @@ let compile_contract ~raise
           let Var lltz_var, lltz_ty, lltz_body =
             Ligo_lltz_codegen.compile_contract contract.binder input_ty e_optimised
           in
-          Lltz_codegen.compile_contract_to_micheline lltz_var lltz_ty lltz_body []
+          Lltz_codegen.compile_contract_to_micheline lltz_var lltz_body []
         in
         let%map expr =
           Lwt.return


### PR DESCRIPTION
# Description
Most recent lltz PR got rid of an arg in compiling contract as it wasn't needed. This PR makes it compatible on the LIGO side too.

# Manual testing 
dune build