### PR TITLE
feat(lltz): improved SLICE codesize

### DIFF
--- a/lib/ligo_lltz_codgen/ligo_lltz_codegen.ml
+++ b/lib/ligo_lltz_codgen/ligo_lltz_codegen.ml
@@ -211,7 +211,7 @@ let compile_constant
               var_name
               seq.type_
               ~body:(O.Dsl.variable ~range (Var var_name) seq.type_))
-         ~none:(O.Dsl.failwith ~range (O.Dsl.string ~range "Slice out of bounds")))
+         ~none:(O.Dsl.failwith ~range (O.Dsl.string ~range "SLICE")))
         .desc
     | _ -> assert false)
   | C_PAIR -> mk_prim (Pair (None, None))


### PR DESCRIPTION
# Description
This PR fixed the last case of a codesize increase with the new backend - the failure message after verification of SLICE result was longer than originally.

# Manual testing
dune build
dune runtest -j 1