### PR TITLE
Clarify decorators for JsLIGO 2.0

### DIFF
--- a/gitlab-pages/docs/syntax/decorators.md
+++ b/gitlab-pages/docs/syntax/decorators.md
@@ -42,6 +42,8 @@ You may encounter them when exporting the Abstract Syntax Tree (AST) after a cer
 
 ## List of attributes
 
+LIGO supports these attributes:
+
 </Syntax>
 
 <Syntax syntax="jsligo">
@@ -55,7 +57,7 @@ Decorators come in two forms:
 The most common use of a decorator is to denote an [entrypoint](../syntax/contracts/entrypoints).
 
 Decorators are placed immediately before the code they apply to.
-You can also apply multiple decorators on one line, as in this example:
+You can also apply multiple decorators to the same piece of code, as in this example:
 
 ```jsligo group=decorators
 type storage = int;
@@ -67,14 +69,32 @@ const sub = (delta: int, storage: storage) : result =>
   [[], storage - delta];
 ```
 
-Note that the lexical convention for decorators clashes with that of [escaped variables](keywords#escaping-keywords).
-Therefore, you cannot escape the name of a decorator and use it as a variable name.
+Decorators must be in comments unless they are within a class.
+For example, this class has decorators that are not in comments:
+
+```jsligo group=decorators
+class Counter {
+
+  @entry
+  @inline
+  add = (value: int, storage: storage): result =>
+    [[], storage + value];
+
+  @entry
+  @deprecated
+  sub = (value: int, storage: storage): result =>
+    [[], storage - value];
+
+  @view
+  get = (_: unit, storage: storage): storage => storage;
+}
+```
 
 ## List of decorators
 
-</Syntax>
-
 LIGO supports these decorators:
+
+</Syntax>
 
 - [`annot`](../reference/decorators/annot)
 - [`deprecated`](../reference/decorators/deprecated)

--- a/gitlab-pages/docs/syntax/src/decorators/decorators.jsligo
+++ b/gitlab-pages/docs/syntax/src/decorators/decorators.jsligo
@@ -5,3 +5,18 @@ type result = [list<operation>, storage];
 // @no_mutation
 const sub = (delta: int, storage: storage) : result =>
   [[], storage - delta];
+class Counter {
+
+  @entry
+  @inline
+  add = (value: int, storage: storage): result =>
+    [[], storage + value];
+
+  @entry
+  @deprecated
+  sub = (value: int, storage: storage): result =>
+    [[], storage - value];
+
+  @view
+  get = (_: unit, storage: storage): storage => storage;
+}


### PR DESCRIPTION
- Clarify when to comment or not comment decorators with examples
- Remove info about escaping because you don't have to do that anymore