### PR TITLE
fix(docs): remove preprocessor info and provide import alternative

### DIFF
--- a/gitlab-pages/docs/compiling/preprocessor.md
+++ b/gitlab-pages/docs/compiling/preprocessor.md
@@ -6,13 +6,26 @@ title: Preprocessor
 import Syntax from '@theme/Syntax';
 
 The preprocessor edits files before they go to the LIGO compiler.
-You can include commands called _preprocessor directives_ to instruct the preprocessor to make changes to a file before the compiler receives it, such as including or excluding code and importing code from other files.
+
+<Syntax syntax="jsligo">
+
+The JsLIGO preprocessor no longer supports preprocessor directives.
+
+- Instead of using the `#include` or `#import` directives, import namespaces in other files directly with the `import` keyword as described in [Importing and using classes](../syntax/classes#importing-and-using-classes) or [Importing namespaces](../syntax/modules#importing-namespaces).
+
+- The `#if`, `#else`, `#elif`, `#endif`, `#define`, `#undef`, and `#error` directives are no longer supported.
+If you need to continue using them, you can run your JsLIGO code through a C++ preprocessor, which uses the same syntax.
+JsLIGO code with these directives does not compile.
+
+</Syntax>
+
+<Syntax syntax="cameligo">
+
+CameLIGO code can include commands called _preprocessor directives_ to instruct the preprocessor to make changes to a file before the compiler receives it, such as including or excluding code and importing code from other files.
 
 Preprocessor directives can allow you to make changes to files before the compiler processes them.
 For example, the following contract has three entrypoints, but one is between `#if` and `#endif` directives.
 The line `#if INCLUDE_RESET` instructs the preprocessor to include the text between the directives (in this case, the third entrypoint) only if the `INCLUDE_RESET` Boolean variable is set:
-
-<Syntax syntax="cameligo">
 
 ```cameligo group=includereset
 module MyContract = struct
@@ -28,10 +41,6 @@ module MyContract = struct
   #endif
 end
 ```
-
-</Syntax>
-
-<Syntax syntax="cameligo">
 
 You can set these Boolean preprocessor variables with the [`#define`](#define-and-undef) directive or by passing them to the `-D` argument of the `ligo compile contract` command.
 For example, if the contract in the previous example is in a file named `mycontract.mligo`, this command causes the preprocessor and compiler to output a contract with only two entrypoints:
@@ -60,6 +69,16 @@ ligo print preprocessed myContract.mligo
 
 </Syntax>
 
+<Syntax syntax="jsligo">
+
+```bash
+ligo print preprocessed myContract.jsligo
+```
+
+</Syntax>
+
+<Syntax syntax="cameligo">
+
 ## Comments
 
 The preprocessor ignores directives that are in [comments](../syntax/comments), which prevents problems where comments in your code contain text that looks like a directive.
@@ -79,15 +98,11 @@ The preprocessor ignores directives that are in strings, which prevents problems
 
 For example, this code includes a string with the text `#endif`, but the preprocessor does not interpret this text as the `#endif` directive:
 
-<Syntax syntax="cameligo">
-
 ```cameligo skip
 #if true
 let textValue = "This string includes the text #endif"
 #endif
 ```
-
-</Syntax>
 
 ## Blank lines
 
@@ -162,7 +177,7 @@ The LIGO compiler ignores these linemarkers when it compiles the code.
 
 ## Directives
 
-These are the preprocessor directives that the LIGO preprocessor supports:
+These are the preprocessor directives that the CameLIGO preprocessor supports:
 
 - [`#define` and `#undef`](#define-and-undef)
 - [`#error`](#error)
@@ -250,8 +265,6 @@ type storage =
 
 ### `#import`
 
-<Syntax syntax="cameligo">
-
 The `#import` directive prompts the preprocessor to include another file as a [module](../syntax/modules) in the current file.
 
 For example, you can create a file with related type definitions, as in this example file named `euro.mligo`:
@@ -277,9 +290,6 @@ let tip (s : storage) : storage = Euro.add (s, Euro.one)
 
 For more information, see [Modules](../syntax/modules).
 
-</Syntax>
-
-
 ### `#include`
 
 The `#include` directive includes the entire text contents of the specified file, as in this example:
@@ -287,8 +297,6 @@ The `#include` directive includes the entire text contents of the specified file
 ```
 #include "path/to/standard_1.mligo"
 ```
-
-<Syntax syntax="cameligo">
 
 Unlike the `#import` directive, the `#include` directive does not package the included file as a module.
 

--- a/gitlab-pages/docs/compiling/preprocessor.md
+++ b/gitlab-pages/docs/compiling/preprocessor.md
@@ -9,7 +9,7 @@ The preprocessor edits files before they go to the LIGO compiler.
 
 <Syntax syntax="jsligo">
 
-The JsLIGO preprocessor no longer supports preprocessor directives.
+The JsLIGO compiler no longer supports preprocessor directives.
 
 - Instead of using the `#include` or `#import` directives, import namespaces in other files directly with the `import` keyword as described in [Importing and using classes](../syntax/classes#importing-and-using-classes) or [Importing namespaces](../syntax/modules#importing-namespaces).
 

--- a/gitlab-pages/docs/syntax/modules.md
+++ b/gitlab-pages/docs/syntax/modules.md
@@ -321,7 +321,43 @@ See [`#import`](../compiling/preprocessor#import).
 
 <Syntax syntax="jsligo">
 
-You can import namespaces from other files with the `#import` directive, but only if the namespaces have the `@public` decorator.
-See [`#import`](../compiling/preprocessor#import).
+## Importing namespaces
+
+You can import namespaces and other definitions from the same file or other files with the `import` keyword in three ways:
+
+- `import M = M.O`
+- `import * as M from "./targetFile.jsligo"`
+- `import {x, y} from "./targetFile.jsligo"`
+
+For example, assume that this file is `myFunctions.jsligo`:
+
+```jsligo group=myFunctions
+export namespace MyFunctions {
+  export const addToImport = (a: int, b: int): int => a + b;
+  export const subToImport = (a: int, b: int): int => a - b;
+}
+```
+
+You can import the file and access the namespace like this:
+
+```jsligo group=useMyFunctions
+import * as MyFileWithFunctions from './gitlab-pages/docs/syntax/src/modules/myFunctions.jsligo';
+const addToImport = MyFileWithFunctions.MyFunctions.addToImport;
+const subToImport = MyFileWithFunctions.MyFunctions.subToImport;
+
+namespace Counter {
+  type storage_type = int;
+  type return_type = [list<operation>, storage_type];
+
+  // @entry
+  const add = (value: int, storage: storage_type): return_type =>
+    [[], addToImport(storage, value)];
+
+  // @entry
+  const sub = (value: int, storage: storage_type): return_type =>
+    [[], subToImport(storage, value)];
+
+}
+```
 
 </Syntax>

--- a/gitlab-pages/docs/syntax/modules.md
+++ b/gitlab-pages/docs/syntax/modules.md
@@ -163,6 +163,84 @@ Client code should always try to respect the interface provided by the namespace
 
 <Syntax syntax="cameligo">
 
+## Importing modules
+
+You can import modules from other files with the `#import` directive.
+See [`#import`](../compiling/preprocessor#import).
+
+</Syntax>
+
+<Syntax syntax="jsligo">
+
+## Importing namespaces
+
+You can import namespaces and other definitions from the same file or other files with the `import` keyword in three ways:
+
+- `import M = M.O`
+- `import * as M from "./targetFile.jsligo"`
+- `import {x, y} from "./targetFile.jsligo"`
+
+For example, assume that this file is `myFunctions.jsligo`:
+
+```jsligo group=myFunctions
+export namespace MyFunctions {
+  export const addToImport = (a: int, b: int): int => a + b;
+  export const subToImport = (a: int, b: int): int => a - b;
+}
+```
+
+You can import the file and access the namespace like this:
+
+```jsligo group=useMyFunctions
+import * as MyFileWithFunctions from './gitlab-pages/docs/syntax/src/modules/myFunctions.jsligo';
+const addToImport = MyFileWithFunctions.MyFunctions.addToImport;
+const subToImport = MyFileWithFunctions.MyFunctions.subToImport;
+
+namespace Counter {
+  type storage_type = int;
+  type return_type = [list<operation>, storage_type];
+
+  // @entry
+  const add = (value: int, storage: storage_type): return_type =>
+    [[], addToImport(storage, value)];
+
+  // @entry
+  const sub = (value: int, storage: storage_type): return_type =>
+    [[], subToImport(storage, value)];
+
+}
+```
+
+</Syntax>
+
+<Syntax syntax="cameligo">
+
+## Including modules
+
+You can include the content of one module inside another with the `include` keyword.
+Including another module in this way can be another way to nest and organize code.
+It can also allow you to upgrade or extend a module, such as by adding new types, functions, and values.
+
+This example extends the `Euro` module by including it in a new `NewEuro` module that has a constant for a 10 Euro note:
+
+```cameligo group=including
+module Euro =
+  struct
+    type t = nat
+    let add (a, b : t * t) : t = a + b
+    let one : t = 1n
+    let two : t = 2n
+  end
+
+module NewEuro =
+  struct
+    include Euro
+    let ten : t = 10n
+  end
+```
+
+Including modules is not possible in JsLIGO.
+
 ## Nesting modules
 
 You can define a module inside another module.
@@ -277,87 +355,5 @@ Now other code can use the Lev just like it is a Euro for now, and you can chang
 You must use the `import` keyword to alias the namespace, even if it is in the same file.
 
 :::
-
-</Syntax>
-
-<Syntax syntax="cameligo">
-
-## Including modules
-
-You can include the content of one module inside another with the `include` keyword.
-Including another module in this way can be another way to nest and organize code.
-It can also allow you to upgrade or extend a module, such as by adding new types, functions, and values.
-
-This example extends the `Euro` module by including it in a new `NewEuro` module that has a constant for a 10 Euro note:
-
-```cameligo group=including
-module Euro =
-  struct
-    type t = nat
-    let add (a, b : t * t) : t = a + b
-    let one : t = 1n
-    let two : t = 2n
-  end
-
-module NewEuro =
-  struct
-    include Euro
-    let ten : t = 10n
-  end
-```
-
-Including modules is not possible in JsLIGO.
-
-</Syntax>
-
-<Syntax syntax="cameligo">
-
-## Importing modules
-
-You can import modules from other files with the `#import` directive.
-See [`#import`](../compiling/preprocessor#import).
-
-</Syntax>
-
-<Syntax syntax="jsligo">
-
-## Importing namespaces
-
-You can import namespaces and other definitions from the same file or other files with the `import` keyword in three ways:
-
-- `import M = M.O`
-- `import * as M from "./targetFile.jsligo"`
-- `import {x, y} from "./targetFile.jsligo"`
-
-For example, assume that this file is `myFunctions.jsligo`:
-
-```jsligo group=myFunctions
-export namespace MyFunctions {
-  export const addToImport = (a: int, b: int): int => a + b;
-  export const subToImport = (a: int, b: int): int => a - b;
-}
-```
-
-You can import the file and access the namespace like this:
-
-```jsligo group=useMyFunctions
-import * as MyFileWithFunctions from './gitlab-pages/docs/syntax/src/modules/myFunctions.jsligo';
-const addToImport = MyFileWithFunctions.MyFunctions.addToImport;
-const subToImport = MyFileWithFunctions.MyFunctions.subToImport;
-
-namespace Counter {
-  type storage_type = int;
-  type return_type = [list<operation>, storage_type];
-
-  // @entry
-  const add = (value: int, storage: storage_type): return_type =>
-    [[], addToImport(storage, value)];
-
-  // @entry
-  const sub = (value: int, storage: storage_type): return_type =>
-    [[], subToImport(storage, value)];
-
-}
-```
 
 </Syntax>

--- a/gitlab-pages/docs/syntax/src/modules/myFunctions.jsligo
+++ b/gitlab-pages/docs/syntax/src/modules/myFunctions.jsligo
@@ -1,0 +1,4 @@
+export namespace MyFunctions {
+  export const addToImport = (a: int, b: int): int => a + b;
+  export const subToImport = (a: int, b: int): int => a - b;
+}

--- a/gitlab-pages/docs/syntax/src/modules/useMyFunctions.jsligo
+++ b/gitlab-pages/docs/syntax/src/modules/useMyFunctions.jsligo
@@ -1,0 +1,17 @@
+import * as MyFileWithFunctions from './gitlab-pages/docs/syntax/src/modules/myFunctions.jsligo';
+const addToImport = MyFileWithFunctions.MyFunctions.addToImport;
+const subToImport = MyFileWithFunctions.MyFunctions.subToImport;
+
+namespace Counter {
+  type storage_type = int;
+  type return_type = [list<operation>, storage_type];
+
+  // @entry
+  const add = (value: int, storage: storage_type): return_type =>
+    [[], addToImport(storage, value)];
+
+  // @entry
+  const sub = (value: int, storage: storage_type): return_type =>
+    [[], subToImport(storage, value)];
+
+}


### PR DESCRIPTION
Hide info about preprocessor directives that are no longer supported and provide info on importing as a workaround.