### PR TITLE
fix(docs): clarify how imports work for different kinds of definitions

### DIFF
--- a/gitlab-pages/docs/intro/src/upgrade-v2/myFunctions.jsligo
+++ b/gitlab-pages/docs/intro/src/upgrade-v2/myFunctions.jsligo
@@ -1,0 +1,4 @@
+export namespace MyFunctions {
+  export const addToImport = (a: int, b: int): int => a + b;
+  export const subToImport = (a: int, b: int): int => a - b;
+}

--- a/gitlab-pages/docs/intro/src/upgrade-v2/topLevelDefinitions.jsligo
+++ b/gitlab-pages/docs/intro/src/upgrade-v2/topLevelDefinitions.jsligo
@@ -1,0 +1,3 @@
+export const addToImport = (a: int, b: int): int => a + b;
+export const subToImport = (a: int, b: int): int => a - b;
+export const myConstant = 5 as int;

--- a/gitlab-pages/docs/intro/src/upgrade-v2/useMyFunctions.jsligo
+++ b/gitlab-pages/docs/intro/src/upgrade-v2/useMyFunctions.jsligo
@@ -1,0 +1,17 @@
+import * as MyFileWithFunctions from './gitlab-pages/docs/intro/src/upgrade-v2/myFunctions.jsligo';
+const addToImport = MyFileWithFunctions.MyFunctions.addToImport;
+const subToImport = MyFileWithFunctions.MyFunctions.subToImport;
+
+namespace Counter {
+  type storage_type = int;
+  type return_type = [list<operation>, storage_type];
+
+  // @entry
+  const add = (value: int, storage: storage_type): return_type =>
+    [[], addToImport(storage, value)];
+
+  // @entry
+  const sub = (value: int, storage: storage_type): return_type =>
+    [[], subToImport(storage, value)];
+
+}

--- a/gitlab-pages/docs/intro/src/upgrade-v2/useTopLevelDefinitions.jsligo
+++ b/gitlab-pages/docs/intro/src/upgrade-v2/useTopLevelDefinitions.jsligo
@@ -1,0 +1,20 @@
+import { addToImport, subToImport, myConstant } from "./gitlab-pages/docs/intro/src/upgrade-v2/topLevelDefinitions.jsligo";
+
+type storage_type = int;
+type return_type = [list<operation>, storage_type];
+
+class Calculator {
+
+  @entry
+  add = (value: int, storage: storage_type): return_type =>
+    [[], addToImport(storage, value)];
+
+  @entry
+  sub = (value: int, storage: storage_type): return_type =>
+    [[], subToImport(storage, value)];
+
+  @entry
+  increment = (_: unit, storage: storage_type): return_type =>
+    [[], addToImport(storage, myConstant)];
+
+}

--- a/gitlab-pages/docs/intro/upgrade-v2.md
+++ b/gitlab-pages/docs/intro/upgrade-v2.md
@@ -256,21 +256,83 @@ It supports three syntaxes for importing definitions from other files and namesp
 - `import * as M from "./targetFile.jsligo"`
 - `import {x, y} from "./targetFile.jsligo"`
 
-However, you cannot import types as in this TypeScript syntax:
+In most cases, to import definitions from other files, use the syntax `import * as M from "./targetFile.jsligo"` to import everything in a file and then create local definitions from that imported file.
+
+For example, assume that this file is `myFunctions.jsligo`:
+
+```jsligo group=myFunctions
+export namespace MyFunctions {
+  export const addToImport = (a: int, b: int): int => a + b;
+  export const subToImport = (a: int, b: int): int => a - b;
+}
+```
+
+You can import the file and access the namespace like this:
+
+```jsligo group=useMyFunctions
+import * as MyFileWithFunctions from './gitlab-pages/docs/intro/src/upgrade-v2/myFunctions.jsligo';
+const addToImport = MyFileWithFunctions.MyFunctions.addToImport;
+const subToImport = MyFileWithFunctions.MyFunctions.subToImport;
+
+namespace Counter {
+  type storage_type = int;
+  type return_type = [list<operation>, storage_type];
+
+  // @entry
+  const add = (value: int, storage: storage_type): return_type =>
+    [[], addToImport(storage, value)];
+
+  // @entry
+  const sub = (value: int, storage: storage_type): return_type =>
+    [[], subToImport(storage, value)];
+
+}
+```
+
+If variables or functions are defined at the top level of the file, you can import them directly with the syntax `import {x, y} from "./targetFile.jsligo"`.
+You cannot import types, classes, or namespaces with this syntax.
+
+For example, assume that this file is `topLevelDefinitions.jsligo`:
+
+```jsligo group=topLevelDefinitions
+export const addToImport = (a: int, b: int): int => a + b;
+export const subToImport = (a: int, b: int): int => a - b;
+export const myConstant = 5 as int;
+```
+
+You can import and use those definitions as in this example:
+
+```jsligo group=useTopLevelDefinitions
+import { addToImport, subToImport, myConstant } from "./gitlab-pages/docs/intro/src/upgrade-v2/topLevelDefinitions.jsligo";
+
+type storage_type = int;
+type return_type = [list<operation>, storage_type];
+
+class Calculator {
+
+  @entry
+  add = (value: int, storage: storage_type): return_type =>
+    [[], addToImport(storage, value)];
+
+  @entry
+  sub = (value: int, storage: storage_type): return_type =>
+    [[], subToImport(storage, value)];
+
+  @entry
+  increment = (_: unit, storage: storage_type): return_type =>
+    [[], addToImport(storage, myConstant)];
+
+}
+```
+
+You cannot import types as in this TypeScript syntax:
 
 ```jsligo skip
 // Not allowed
 import { type x } from "./myTypes.jsligo";
 ```
 
-Instead, import the file and bind a type locally, as in this example:
-
-```jsligo skip
-import * as myTypes from "./myTypes.jsligo";
-type storage_type = myTypes.storage_type;
-type return_type = myTypes.return_type;
-```
-
+Instead, import the file and bind a type locally.
 For example, assume that this file is `myTypes.jsligo`:
 
 ```jsligo group=myTypes

--- a/gitlab-pages/docs/syntax/modules.md
+++ b/gitlab-pages/docs/syntax/modules.md
@@ -174,11 +174,10 @@ See [`#import`](../compiling/preprocessor#import).
 
 ## Importing namespaces
 
-You can import namespaces and other definitions from the same file or other files with the `import` keyword in three ways:
+You can import namespaces from the same file or other files with the `import` keyword in these ways:
 
 - `import M = M.O`
 - `import * as M from "./targetFile.jsligo"`
-- `import {x, y} from "./targetFile.jsligo"`
 
 For example, assume that this file is `myFunctions.jsligo`:
 


### PR DESCRIPTION
There are 3 syntaxes for imports but different ones work for different kinds of definitions. Clarify what works for what kind.