### PR TITLE
fix(docs): correct testing link on home page

### DIFF
--- a/gitlab-pages/website/src/components/HomepageFeatures/index.js
+++ b/gitlab-pages/website/src/components/HomepageFeatures/index.js
@@ -28,7 +28,7 @@ const FEATURES = [
     title: "Testing System",
     content:
       "Ligo uses a robust testing system to simulate the Tezos blockchain, as if you were inside.",
-    link: "docs/advanced/testing",
+    link: "docs/testing",
   },
   {
     image: "img/ligo_features/ligo-feature-community.svg",


### PR DESCRIPTION
This link on the home page has changed to docs/testing.