### PR TITLE
fix(docs): Clarify changes in pattern matching

### DIFF
--- a/gitlab-pages/docs/intro/upgrade-v2.md
+++ b/gitlab-pages/docs/intro/upgrade-v2.md
@@ -346,6 +346,66 @@ const manager2: user = ["Manager" as "Manager", 2 as int];
 const guest3: user = ["Guest" as "Guest"];
 ```
 
+## Pattern matching
+
+The syntax for pattern matching has changed to use the `$match` predefined function instead of the `match` keyword.
+As its parameters, the `$match` function receives the variant value to match on and an object.
+The property names of the object are the constructors of the corresponding variant type.
+The property values are either a single expression or functions that receive the value of the variant as a parameter.
+Here is an example:
+
+```jsligo group=matching
+type user =
+  ["Admin", nat]
+| ["Manager", nat]
+| ["Guest"];
+
+const greetUser = (user: user): string => {
+  $match (user, {
+    "Admin": _id => "Hello, administrator",
+    "Manager": _id => "Welcome, manager",
+    "Guest": () => "Hello, guest",
+  });
+}
+```
+
+To define the thunk, use an immediately invoked function expression (IIFE) as the result of a match, as in the following example.
+JsLIGO 2.0 uses this syntax in place of `do` expressions in the previous version.
+
+```jsligo group=matching
+const getSquareOfUserId = (user: user): nat => {
+  $match (user, {
+    "Admin": id => (() => {
+      const squareOfId = id * id;
+      return squareOfId;
+    })(),
+    "Manager": id => (() => {
+      const squareOfId = id * id;
+      return squareOfId;
+    })(),
+    "Guest": () => 0,
+  });
+}
+```
+
+Matching works only on values of variant types.
+If you want to use the `$match` statement on other types or on more than one variable at a time, you can wrap them in a variant or option.
+This example wraps two types in a variant so the `$match` statement can use them both:
+
+```jsligo group=matching
+type wrapper = | ["Wrap", [int, int]];
+const wrapped: wrapper = ["Wrap" as "Wrap", [5, 5]];
+
+const compareResult: string = $match(wrapped, {
+  "Wrap": ([_a, _b]) => (() => {
+    if (_a == _b) return "Equal";
+    if (_a > _b) return "Greater";
+    if (_a < _b) return "Less";
+    return "Default";
+  })(),
+});
+```
+
 ## Imports
 
 JsLIGO now uses a syntax closer to JavaScript/TypeScript to import definitions.
@@ -467,66 +527,6 @@ Here are some ways to update code that uses preprocessor directives:
 - The `#if`, `#else`, `#elif`, `#endif`, `#define`, `#undef`, and `#error` directives are no longer supported.
 If you need to continue using them, you can run your JsLIGO code through a C++ preprocessor, which uses the same syntax.
 JsLIGO code with these directives does not compile.
-
-## Pattern matching
-
-The syntax for pattern matching has changed to use the `$match` predefined function instead of the `match` keyword.
-As its parameters, the `$match` function receives the variant value to match on and an object.
-The property names of the object are the constructors of the corresponding variant type.
-The property values are either a single expression or functions that receive the value of the variant as a parameter.
-Here is an example:
-
-```jsligo group=matching
-type user =
-  ["Admin", nat]
-| ["Manager", nat]
-| ["Guest"];
-
-const greetUser = (user: user): string => {
-  $match (user, {
-    "Admin": _id => "Hello, administrator",
-    "Manager": _id => "Welcome, manager",
-    "Guest": () => "Hello, guest",
-  });
-}
-```
-
-To define the thunk, use an immediately invoked function expression (IIFE) as the result of a match, as in the following example.
-JsLIGO 2.0 uses this syntax in place of `do` expressions in the previous version.
-
-```jsligo group=matching
-const getSquareOfUserId = (user: user): nat => {
-  $match (user, {
-    "Admin": id => (() => {
-      const squareOfId = id * id;
-      return squareOfId;
-    })(),
-    "Manager": id => (() => {
-      const squareOfId = id * id;
-      return squareOfId;
-    })(),
-    "Guest": () => 0,
-  });
-}
-```
-
-Also, matching works only on values of variant types.
-If you want to use the `$match` statement on other types or on more than one variable at a time, you can wrap them in a variant or option.
-This example wraps two types in a variant so the `$match` statement can use them both:
-
-```jsligo group=matching
-type wrapper = | ["Wrap", [int, int]];
-const wrapped: wrapper = ["Wrap" as "Wrap", [5, 5]];
-
-const compareResult: string = $match(wrapped, {
-  "Wrap": ([_a, _b]) => (() => {
-    if (_a == _b) return "Equal";
-    if (_a > _b) return "Greater";
-    if (_a < _b) return "Less";
-    return "Default";
-  })(),
-});
-```
 
 ## The `switch` statement
 

--- a/gitlab-pages/docs/intro/upgrade-v2.md
+++ b/gitlab-pages/docs/intro/upgrade-v2.md
@@ -406,6 +406,56 @@ const compareResult: string = $match(wrapped, {
 });
 ```
 
+Also, match cases can accept only one parameter.
+In LIGO v1, the following match statement was allowed; note that the match expression for the `RGB` case accepts three parameters, one for each of the values in the variant:
+
+```jsligo skip
+type colour =
+| ["RGB", [int, int, int]]
+| ["Gray", int]
+| ["Default"];
+
+let colourInt: colour = RGB(1, 2, 3);
+let result = match(colourInt) {
+  when(Gray(val)): do {
+    const a = 5n;
+    const b = 6n;
+    return a + b + abs(val);
+  };
+  when(RGB(a, b, c)): do {
+    return abs(a + b + c);
+  }
+  when(Default): do {
+    return 5n;
+  };
+}
+```
+
+The equivalent match expression in LIGO v2 accepts only one parameter, a tuple that contains the values from the variant case:
+
+```jsligo group=match_case_tuple
+type colour =
+  ["RGB", [int, int, int]] | ["Gray", int] | ["Default"];
+
+let colourInt: colour = ["RGB" as "RGB", 1, 2, 3];
+let result =
+  $match(colourInt, {
+    "Gray": (val) =>
+      (() =>
+      {
+        const a = (5 as nat);
+        const b = (6 as nat);
+        return a + b + abs(val);
+      })(),
+    "RGB": ([a, b, c]) =>
+      (() =>
+      { return abs(a + b + c); })(),
+    "Default": () =>
+      (() =>
+      { return (5 as nat); })(),
+  })
+```
+
 ## Imports
 
 JsLIGO now uses a syntax closer to JavaScript/TypeScript to import definitions.


### PR DESCRIPTION
Moved pattern matching changes near info about variants and clarified a change in the cases for variants.