### PR TITLE
These examples would be clearer in a namespace

### DIFF
--- a/gitlab-pages/website/src/components/HomepageCodeExamples/cameligo.mligo
+++ b/gitlab-pages/website/src/components/HomepageCodeExamples/cameligo.mligo
@@ -1,15 +1,18 @@
-type storage = int
+module Counter = struct
+  type storage_type = int
+  type return_type = operation list * storage_type
 
-type ret = operation list * storage
+  (* Three entrypoints *)
 
-(* Three entrypoints *)
+  [@entry]
+  let add (value : int) (store : storage_type) : return_type =
+    [], store + value
 
-[@entry]
-let increment (delta : int) (store : storage) : ret = [], store + delta
+  [@entry]
+  let sub (value : int) (store : storage_type) : return_type =
+    [], store - value
 
-[@entry]
-let decrement (delta : int) (store : storage) : ret = [], store - delta
-
-[@entry]
-let reset (() : unit) (_ : storage) : ret = [], 0
-
+  [@entry]
+  let reset (_p : unit) (_s : storage_type) : return_type =
+    [], 0
+end

--- a/gitlab-pages/website/src/components/HomepageCodeExamples/jsligo.jsligo
+++ b/gitlab-pages/website/src/components/HomepageCodeExamples/jsligo.jsligo
@@ -1,15 +1,18 @@
-type storage = int;
-type ret = [list<operation>, storage];
+namespace Counter {
+  type storage_type = int;
+  type return_type = [list<operation>, storage_type];
 
-// Three entrypoints
+  // Three entrypoints
 
-// @entry
-const increment = (delta: int, store: storage): ret =>
-  [[], store + delta];
+  // @entry
+  const add = (value: int, store: storage_type): return_type =>
+    [[], store + value];
 
-// @entry
-const decrement = (delta: int, store: storage): ret =>
-  [[], store - delta];
+  // @entry
+  const sub = (value: int, store: storage_type): return_type =>
+    [[], store - value];
 
-// @entry
-const reset = (_p: unit, _s: storage): ret => [[], 0]
+  // @entry
+  const reset = (_p: unit, _s: storage_type): return_type =>
+    [[], 0];
+}


### PR DESCRIPTION
I think these should be in a namespace/struct for clarity. In the case of jsligo it's necessary to know whether the `@entry` annotation should be in a comment or not.