### PR TITLE
fix(docs): restore jsligo keywords

### DIFF
--- a/gitlab-pages/docs/intro/upgrade-v2.md
+++ b/gitlab-pages/docs/intro/upgrade-v2.md
@@ -603,6 +603,7 @@ const test = (() => {
 
 Escaping keywords is no longer supported; keywords cannot be used as variable names or object fields, even if you prefix the names with the `@` symbol.
 For example, you can add an underscore as a suffix, creating variables with names such as `return_` or `entry_`.
+See [Keywords](../syntax/keywords).
 
 ## Decorators
 

--- a/gitlab-pages/docs/syntax/keywords.md
+++ b/gitlab-pages/docs/syntax/keywords.md
@@ -5,15 +5,13 @@ title: Keywords
 
 import Syntax from '@theme/Syntax';
 
-_Keywords_ are reserved words that cannot be used as names in declarations.
-In some cases you can escape keywords to use them as variables or record fields.
+_Keywords_ are reserved words that cannot be used as names in declarations such as variables and record fields.
 
 <Syntax syntax="cameligo">
 
 ## Escaping keywords
 
-Keywords cannot be used as variables or record fields. If you need to
-use a keyword as a variable, you can prefix it with `@`, like so:
+If you need to use a keyword as a variable name, you can prefix it with `@`, as in this example:
 
 ```cameligo group=keywords
 let @from = ("tz1fakefakefakefakefakefakefakcphLA5" : address)
@@ -21,7 +19,53 @@ let @from = ("tz1fakefakefakefakefakefakefakcphLA5" : address)
 
 </Syntax>
 
+<Syntax syntax="jsligo">
+
+Unlike in previous versions of JsLIGO, you cannot start variable names with an `@` symbol and therefore you cannot escape keywords by putting an `@` symbol in front of their names.
+You can modify the keywords in other ways, such as adding an underscore to the end.
+
+</Syntax>
+
 ## List of keywords
+
+<Syntax syntax="jsligo">
+
+JsLIGO's keywords are the following:
+
+- `as`
+- `break`
+- `case`
+- `const`
+- `continue`
+- `contract_of`
+- `default`
+- `do`
+- `else`
+- `export`
+- `false`
+- `for`
+- `from`
+- `function`
+- `if`
+- `implements`
+- `import`
+- `interface`
+- `let`
+- `match`
+- `namespace`
+- `of`
+- `parameter_of`
+- `return`
+- `switch`
+- `true`
+- `type`
+- `when`
+- `while`
+
+JslIGO may allow you to create and use variables with these names in some cases, but for some uses the compiler fails to compile contracts that use variables with these names.
+Therefore, do not use variables with these names even if the contract appears to work.
+
+</Syntax>
 
 <Syntax syntax="cameligo">
 CameLIGO's keywords are the following:


### PR DESCRIPTION
We removed the list of JsLIGO keywords because you can no longer escape them, but it seems to me that we should still have a list of  reserved words, because using these words as variable names can crash the compiler. For example, I'll post a contract below that seems to lock up the compiler.

@EduardoRFS This is the list of keywords from jsligo 1.x with the `@` keywords removed because apparently you can't create a variable name that starts with `@`. Is there a way to get the full list from the code?

```
type storage_type = nat;
type return_type = [list<operation>, storage_type];

class Counter {

  @entry
  static add = (value: nat, store: storage_type): return_type => {
    const else = 5 as nat;
    const export = 5 as nat;
    const false = 5 as nat;
    const for = 5 as nat;
    const from = 5 as nat;
    const if = 5 as nat;
    const implements = 5 as nat;
    const interface = 5 as nat;
    const let = 5 as nat;
    const match = 5 as nat;
    const namespace = 5 as nat;
    const of = 5 as nat;
    const parameter_of = 5 as nat;
    const return = 5 as nat;
    const switch = 5 as nat;
    const true = 5 as nat;
    const type = 5 as nat;
    const when = 5 as nat;
    const while = 5 as nat;
    const sum = else + export + false + for + from + if + implements + interface + let + match + namespace + of + parameter_of + return + switch + true + type + when + while;
    return [[], store + value];
  }

  @entry
  static sub = (value: nat, store: storage_type): return_type =>
    [[], abs(store - value)];

  @view
  static getValue = (_: unit, storage: storage_type): storage_type =>
    storage;
}
``` 