### PR TITLE
fix(docs): add icon for external links

### DIFF
--- a/gitlab-pages/website/src/css/custom.css
+++ b/gitlab-pages/website/src/css/custom.css
@@ -116,6 +116,16 @@ h4 {
   font-size: 1.125rem;
 }
 
+/* icon for external links */
+[data-theme="light"] article a[target="_blank"]:after {
+  content: url("/img/external_link_light.svg");
+  padding-left: 5px;
+}
+[data-theme="dark"] article a[target="_blank"]:after {
+  content: url("/img/external_link_dark.svg");
+  padding-left: 5px;
+}
+
 blockquote {
   background-color: var(--blockquote-color);
   border-left: 5px solid var(--ligo-color_content-primary);

--- a/gitlab-pages/website/static/img/external_link_dark.svg
+++ b/gitlab-pages/website/static/img/external_link_dark.svg
@@ -1,0 +1,1 @@
+<svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="iconExternalLink_node_modules-@docusaurus-theme-classic-lib-theme-Icon-ExternalLink-styles-module"><path fill="white" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg>

--- a/gitlab-pages/website/static/img/external_link_light.svg
+++ b/gitlab-pages/website/static/img/external_link_light.svg
@@ -1,0 +1,1 @@
+<svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="iconExternalLink_node_modules-@docusaurus-theme-classic-lib-theme-Icon-ExternalLink-styles-module"><path d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg>


### PR DESCRIPTION
Add an icon for links that go to external sites.

Preview: https://timothymcmackin.github.io/previews/ligo/external-link-icon/docs/next/intro/introduction?lang=jsligo

<img width="859" height="245" alt="Screenshot 2025-08-01 at 10 47 58 AM" src="https://github.com/user-attachments/assets/738272d0-702b-45e0-96a2-fca808dbf76e" />
